### PR TITLE
fix(models): cloud model Run button does nothing

### DIFF
--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -92,9 +92,10 @@ export const useModelStore = defineStore('models', {
     /**
      * Ensures a cloud model is available by pulling it if not already installed.
      */
-    async fetchLibraryTags(slug: string) {
+    async fetchLibraryTags(slug: string): Promise<string[]> {
       try {
-        return await invoke<string[]>('get_library_tags', { slug });
+        const tags = await invoke<LibraryTag[]>('get_library_tags', { slug });
+        return tags.map(t => t.name);
       } catch (e) {
         console.error(`Failed to fetch tags for ${slug}`, e);
         return [];


### PR DESCRIPTION
## Summary

- `get_library_tags` returns `Vec<LibraryTag>` objects from the Rust backend, but `fetchLibraryTags` in the models store was typed as `invoke<string[]>`
- At runtime `allTags` held objects, so `t.toLowerCase()` in `openCloudModel` threw `TypeError: t.toLowerCase is not a function`
- The `try/finally` block had no `catch`, so Vue swallowed the rejection silently — the Run button appeared to do nothing

**Fix:** deserialize as `LibraryTag[]` and map to `.name` strings, preserving the `string[]` contract for all downstream callers (`tagSelector.tags`, `CloudTagSelector`).

## Test plan

- [ ] Switch to the Cloud tab on the Models page
- [ ] Click **Run** on any cloud model — should show the "Resolving cloud versions..." overlay, then navigate to Chat with that model selected
- [ ] If a model has multiple cloud tags, the `CloudTagSelector` modal should appear instead
- [ ] Run `vue-tsc --noEmit` — zero type errors