### PR TITLE
fix(chat): collapsible thinking block, collapsed search results, scroll freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Chat: thinking block can now be collapsed/expanded while the LLM is still thinking (#7)
+- Chat: web search results are collapsed by default when search completes; user can expand manually (#8)
+- Chat: auto-scroll no longer freezes after manually scrolling up then back down (#9)
+- Chat: auto-scroll now works correctly when opening a saved conversation after restart (#9)
+- Chat: switching conversations always resets scroll to bottom (#9)
+
 ---
 
 ## [1.0.1] - 2026-04-27

--- a/src/components/chat/ChatView.vue
+++ b/src/components/chat/ChatView.vue
@@ -306,13 +306,18 @@ async function onStop() {
   await stopGeneration()
 }
 
+// Timer used to guard onScroll from re-disabling auto-scroll during a programmatic smooth scroll.
+// Cleared either by scrollend event (preferred) or a 500ms fallback.
+let _smoothScrollTimer: ReturnType<typeof setTimeout> | null = null
+
 function onScroll() {
   if (!scrollContainer.value) return
+  // Skip intermediate scroll events triggered by our own scrollToBottom('smooth') call.
+  if (_smoothScrollTimer !== null) return
 
   const el = scrollContainer.value
   const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight
 
-  // Increased tolerance (100px) creates a less sensitive but still accurate auto-scroll pause
   if (distanceToBottom > 100) {
     isAutoScrollEnabled.value = false
   } else {
@@ -328,31 +333,55 @@ function scrollToBottom(behavior: ScrollBehavior = 'smooth') {
   if (!scrollContainer.value) return
   isAutoScrollEnabled.value = true
 
+  // nextTick + rAF ensures DynamicScroller has completed its ResizeObserver-driven layout
+  // before we read scrollHeight, fixing the "0px scrollHeight on conversation open" bug.
   nextTick(() => {
-    if (!scrollContainer.value) return
-    const el = scrollContainer.value
-    el.scrollTo({
-      top: el.scrollHeight,
-      behavior,
+    requestAnimationFrame(() => {
+      if (!scrollContainer.value) return
+      const el = scrollContainer.value
+      el.scrollTo({ top: el.scrollHeight, behavior })
+
+      if (behavior === 'smooth') {
+        // Guard onScroll for the duration of the animation. scrollend fires when the
+        // browser finishes; the 500ms timer is a safety net for older WebKitGTK builds.
+        if (_smoothScrollTimer) clearTimeout(_smoothScrollTimer)
+        _smoothScrollTimer = setTimeout(() => {
+          _smoothScrollTimer = null
+          onScroll()
+        }, 500)
+        el.addEventListener('scrollend', () => {
+          if (_smoothScrollTimer) {
+            clearTimeout(_smoothScrollTimer)
+            _smoothScrollTimer = null
+          }
+          onScroll()
+        }, { once: true })
+      }
     })
   })
 }
 
-// Collapse system prompt when switching conversations
+// Reset scroll state and collapse system prompt when switching conversations.
+// Resetting isAutoScrollEnabled here ensures the itemsForScroller watcher below
+// will scroll to bottom once the new conversation's messages arrive.
 watch(
   () => chatStore.activeConversationId,
-  () => { isSystemPromptExpanded.value = false }
+  () => {
+    isSystemPromptExpanded.value = false
+    isAutoScrollEnabled.value = true
+  }
 )
 
-// Auto-scroll when new content arrives
+// Auto-scroll when new content arrives.
+// flush: 'post' ensures we read scrollHeight after the DOM (including DynamicScroller) has updated.
 watch(
   () => itemsForScroller.value,
   () => {
     if (isAutoScrollEnabled.value) {
-      // Use 'auto' behavior during content arrival (streaming) for maximum responsiveness
       scrollToBottom('auto')
     }
-  }
+  },
+  { flush: 'post' }
 )
 
 onMounted(async () => {

--- a/src/components/chat/SearchBlock.vue
+++ b/src/components/chat/SearchBlock.vue
@@ -84,7 +84,7 @@ const props = defineProps<{
 const { isOpen, toggle: _toggle } = useCollapsibleState({
   messageKey: props.messageKey,
   suffix: 'search',
-  initialOpen: true, // Let's keep it open by default when a result comes in
+  initialOpen: false,
 })
 
 const toggleCollapse = (event: MouseEvent) => {

--- a/src/components/chat/ThinkBlock.vue
+++ b/src/components/chat/ThinkBlock.vue
@@ -55,7 +55,7 @@ const { isOpen, toggle: _toggle, setOpen } = useCollapsibleState({
   initialOpen: props.isThinking,
 })
 
-const isExpanded = computed(() => props.isThinking ? true : isOpen.value)
+const isExpanded = computed(() => isOpen.value)
 const contentEl = ref<HTMLElement | null>(null)
 
 const label = computed(() => {
@@ -71,11 +71,11 @@ const renderedContent = computed(() => renderMarkdown(props.content))
 
 function toggle(event: MouseEvent) {
   event.stopPropagation()
-  if (!props.isThinking) _toggle()
+  _toggle()
 }
 
 watch(() => props.content, async () => {
-  if (!props.isThinking || !isExpanded.value) return
+  if (!props.isThinking || !isOpen.value) return
   await nextTick()
   if (contentEl.value) {
     contentEl.value.scrollTop = contentEl.value.scrollHeight


### PR DESCRIPTION
## What does this PR do?

Fixes three chat UI bugs: thinking block cannot be collapsed during streaming, web search results always open, and auto-scroll freezes in two scenarios.

## Related issue

Closes #7
Closes #8
Closes #9

## Type

- [x] `type: bug` — fixes broken behaviour

## Test plan

- [x] Send message to a thinking model (e.g. deepseek-r1); click the thinking block header while it's streaming → block collapses and stays collapsed when stream ends
- [x] Trigger a web search; when results arrive, the search block is collapsed by default; clicking expands it
- [x] Scroll up during streaming, then click "Jump to present" → smooth scroll completes, auto-scroll stays enabled, next token scrolls
- [x] Open fresh app, click a saved conversation with many messages → chat scrolls to bottom
- [x] In conversation A scroll up (disabling auto-scroll), switch to conversation B → B auto-scrolls to bottom

## Checklist

- [x] Branch follows GitFlow naming (`bugfix/chat-ui-streaming-issues`)
- [x] CI passes (`Security Audit` + `Build Check`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `docs/ARCHITECTURE.md` updated if commands, events, or schema changed — not applicable (UI-only changes)