### PR TITLE
fix(build): align Tauri plugin NPM versions with Rust crates — v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [1.1.1] - 2026-04-28
+
+### Fixed
+- Build: align `@tauri-apps/plugin-fs` (2.4.5→2.5.0) and `@tauri-apps/plugin-dialog` (2.6.0→2.7.0) NPM packages with Rust crate versions to fix release CI failure (#12)
+
+---
+
 ## [1.1.0] - 2026-04-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alpaka-desktop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Native Linux desktop client for Ollama",
   "private": true,
   "type": "module",
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",
-    "@tauri-apps/plugin-dialog": "^2.0.0",
-    "@tauri-apps/plugin-fs": "^2.0.0",
+    "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-fs": "^2.5.0",
     "@tauri-apps/plugin-global-shortcut": "^2.0.0",
     "@tauri-apps/plugin-notification": "^2.0.0",
     "@traptitech/markdown-it-katex": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^2.0.0
         version: 2.10.1
       '@tauri-apps/plugin-dialog':
-        specifier: ^2.0.0
-        version: 2.6.0
+        specifier: ^2.7.0
+        version: 2.7.0
       '@tauri-apps/plugin-fs':
-        specifier: ^2.0.0
-        version: 2.4.5
+        specifier: ^2.5.0
+        version: 2.5.0
       '@tauri-apps/plugin-global-shortcut':
         specifier: ^2.0.0
         version: 2.3.1
@@ -851,11 +851,11 @@ packages:
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-dialog@2.6.0':
-    resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
+  '@tauri-apps/plugin-dialog@2.7.0':
+    resolution: {integrity: sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==}
 
-  '@tauri-apps/plugin-fs@2.4.5':
-    resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
+  '@tauri-apps/plugin-fs@2.5.0':
+    resolution: {integrity: sha512-c83kbz61AK+rKjhS+je9+stIO27nXj7p9cqeg36TwkIUtxpCFTttlHHtqon6h6FN54cXjyAjlMPOJcW3mwE5XQ==}
 
   '@tauri-apps/plugin-global-shortcut@2.3.1':
     resolution: {integrity: sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g==}
@@ -2674,11 +2674,11 @@ snapshots:
       '@tauri-apps/cli-win32-ia32-msvc': 2.10.1
       '@tauri-apps/cli-win32-x64-msvc': 2.10.1
 
-  '@tauri-apps/plugin-dialog@2.6.0':
+  '@tauri-apps/plugin-dialog@2.7.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-fs@2.4.5':
+  '@tauri-apps/plugin-fs@2.5.0':
     dependencies:
       '@tauri-apps/api': 2.10.1
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "alpaka-desktop"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaka-desktop"
-version = "1.1.0"
+version = "1.1.1"
 description = "Native desktop client for Ollama"
 authors = ["nikoteressi@gmail.com"]
 edition = "2021"
@@ -18,8 +18,8 @@ tauri-build = { version = "2.5", features = [] }
 tauri = { version = "2.10", features = ["tray-icon", "image-png"] }
 
 # ── Tauri official plugins ──────────────────────────────────────────────────
-tauri-plugin-fs           = "2.4"
-tauri-plugin-dialog       = "2.6"
+tauri-plugin-fs           = "2.5"
+tauri-plugin-dialog       = "2.7"
 tauri-plugin-notification = "2.3"
 tauri-plugin-global-shortcut = "2.3"
 tauri-plugin-log          = "2.8"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "alpaka-desktop",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "io.alpaka.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## What does this PR do?

Hotfix for the release CI failure caused by Rust/NPM Tauri plugin version mismatch introduced by Dependabot.

## Related issue

Closes #12

## Type

- [x] `type: hotfix` — critical fix for a released version

## Root cause

Dependabot bumped the Rust crates in `Cargo.lock` but left the NPM packages behind. Tauri CLI enforces that `major.minor` must match across the language boundary.

| Package | NPM (was) | NPM (now) | Rust |
|---------|-----------|-----------|------|
| `plugin-fs` | 2.4.5 | **2.5.0** | 2.5.0 |
| `plugin-dialog` | 2.6.0 | **2.7.0** | 2.7.0 |

## Test plan

- [ ] CI build passes on this PR
- [ ] Release workflow completes `pnpm tauri build` without version mismatch error

## Checklist

- [x] Branch follows GitFlow naming (`hotfix/`)
- [x] `CHANGELOG.md` updated under new `[1.1.1]` entry
- [x] Version bumped to 1.1.1 across `package.json`, `tauri.conf.json`, `Cargo.toml`