### PR TITLE
feat(cloud): inject API key for Ollama Cloud requests (CL-05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- CL-05: Ollama Cloud routing — stored API key is now injected as `Authorization: Bearer` on all requests to `api.ollama.com` hosts. Missing key surfaces a friendly error in the chat rather than a raw network failure. Saving a key for the first time auto-adds the Ollama Cloud host entry.
+
 ### Changed
 - CI: merge duplicate `test` + `coverage` jobs into single `test-and-coverage` (tests now run once with instrumentation instead of twice)
 - CI: add path-based job skipping — Rust-only PRs skip Vitest/TS checks; frontend-only PRs skip Rust compilation/testing

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -158,10 +158,9 @@ pub async fn trigger_ollama_signin() -> Result<String, AppError> {
     ))
 }
 
-/// Stores an Ollama API key in the system keyring under the fixed
-/// [`API_KEY_ACCOUNT`] identifier, separate from per-host OAuth tokens.
-#[command]
-pub async fn set_api_key(key: String) -> Result<(), AppError> {
+/// Core logic for storing the API key, without side-effects.
+/// Extracted so tests can call it without a live Tauri `AppState`.
+pub async fn core_set_api_key(key: String) -> Result<(), AppError> {
     let key = key.trim().to_string();
     if key.is_empty() {
         return Err(AppError::Auth("API key must not be empty".into()));
@@ -172,6 +171,45 @@ pub async fn set_api_key(key: String) -> Result<(), AppError> {
         ));
     }
     tokio::task::spawn_blocking(move || keyring::set_token(API_KEY_ACCOUNT, &key)).await??;
+    Ok(())
+}
+
+/// Adds `https://api.ollama.com` as a host entry if no cloud host exists yet.
+/// Best-effort — errors are ignored so a keyring failure never blocks key storage.
+pub async fn ensure_cloud_host_exists(db: crate::db::DbConn) -> Result<(), AppError> {
+    tokio::task::spawn_blocking(move || {
+        let conn = db
+            .lock()
+            .map_err(|_| AppError::Db("Database lock poisoned".into()))?;
+        let hosts = crate::db::hosts::list_all(&conn)?;
+        let has_cloud = hosts
+            .iter()
+            .any(|h| crate::ollama::client::is_cloud_host(&h.url));
+        if !has_cloud {
+            crate::db::hosts::create(
+                &conn,
+                crate::db::hosts::NewHost {
+                    name: "Ollama Cloud".into(),
+                    url: "https://api.ollama.com".into(),
+                    is_default: Some(false),
+                },
+            )?;
+        }
+        Ok(())
+    })
+    .await?
+}
+
+/// Stores an Ollama API key in the system keyring under the fixed
+/// [`API_KEY_ACCOUNT`] identifier, separate from per-host OAuth tokens.
+/// Also auto-adds the Ollama Cloud host entry if it does not exist yet.
+#[command]
+pub async fn set_api_key(
+    state: tauri::State<'_, crate::state::AppState>,
+    key: String,
+) -> Result<(), AppError> {
+    core_set_api_key(key).await?;
+    let _ = ensure_cloud_host_exists(state.db.clone()).await;
     Ok(())
 }
 
@@ -334,7 +372,7 @@ mod tests {
     #[tokio::test]
     async fn test_set_api_key_validation() {
         // Empty key is rejected
-        let res = set_api_key("".to_string()).await;
+        let res = core_set_api_key("".to_string()).await;
         match res {
             Err(AppError::Auth(msg)) if msg.contains("empty") => (),
             Ok(_) => panic!("Empty key should be rejected"),
@@ -342,7 +380,7 @@ mod tests {
         }
 
         // Whitespace-only key is rejected
-        let res = set_api_key("   ".to_string()).await;
+        let res = core_set_api_key("   ".to_string()).await;
         match res {
             Err(AppError::Auth(msg)) if msg.contains("empty") => (),
             Ok(_) => panic!("Whitespace-only key should be rejected"),
@@ -357,7 +395,7 @@ mod tests {
         // execution without this guard.
         let _lock = API_KEY_TEST_LOCK.lock().unwrap();
 
-        let set_res = set_api_key("sk-test-cmd-key-abc".to_string()).await;
+        let set_res = core_set_api_key("sk-test-cmd-key-abc".to_string()).await;
         if let Err(ref e) = set_res {
             let msg = format!("{e:?}");
             if msg.contains("No secret-service")
@@ -448,6 +486,74 @@ mod tests {
             Err(AppError::NotFound(_)) => (), // Host not found in in-memory DB edge case
             Err(e) => panic!("Unexpected error from perform_validate_api_key: {:?}", e),
         }
+    }
+
+    #[tokio::test]
+    async fn test_ensure_cloud_host_exists_adds_host() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::migrations::run(&conn).unwrap();
+        let db: DbConn = Arc::new(Mutex::new(conn));
+
+        // No hosts yet — ensure_cloud_host_exists should add the cloud host.
+        ensure_cloud_host_exists(db.clone()).await.unwrap();
+
+        let conn = db.lock().unwrap();
+        let hosts = crate::db::hosts::list_all(&conn).unwrap();
+        assert_eq!(hosts.len(), 1);
+        assert!(crate::ollama::client::is_cloud_host(&hosts[0].url));
+        assert_eq!(hosts[0].name, "Ollama Cloud");
+    }
+
+    #[tokio::test]
+    async fn test_ensure_cloud_host_exists_is_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::migrations::run(&conn).unwrap();
+        let db: DbConn = Arc::new(Mutex::new(conn));
+
+        // Call twice — should only add one cloud host.
+        ensure_cloud_host_exists(db.clone()).await.unwrap();
+        ensure_cloud_host_exists(db.clone()).await.unwrap();
+
+        let conn = db.lock().unwrap();
+        let hosts = crate::db::hosts::list_all(&conn).unwrap();
+        let cloud_count = hosts
+            .iter()
+            .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+            .count();
+        assert_eq!(cloud_count, 1, "should have exactly one cloud host");
+    }
+
+    #[tokio::test]
+    async fn test_ensure_cloud_host_exists_skips_if_already_present() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::migrations::run(&conn).unwrap();
+        crate::db::seed_default_host(&conn).unwrap();
+        let db: DbConn = Arc::new(Mutex::new(conn));
+
+        // Manually add a cloud host first.
+        {
+            let conn = db.lock().unwrap();
+            crate::db::hosts::create(
+                &conn,
+                crate::db::hosts::NewHost {
+                    name: "My Cloud".into(),
+                    url: "https://api.ollama.com".into(),
+                    is_default: Some(false),
+                },
+            )
+            .unwrap();
+        }
+
+        // ensure_cloud_host_exists must not add a second one.
+        ensure_cloud_host_exists(db.clone()).await.unwrap();
+
+        let conn = db.lock().unwrap();
+        let cloud_count = crate::db::hosts::list_all(&conn)
+            .unwrap()
+            .iter()
+            .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+            .count();
+        assert_eq!(cloud_count, 1, "should still have exactly one cloud host");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/auth.rs
+++ b/src-tauri/src/commands/auth.rs
@@ -220,11 +220,39 @@ pub async fn get_api_key_status() -> Result<String, AppError> {
     Ok(if token.is_some() { "set" } else { "not_set" }.to_string())
 }
 
-/// Removes the API key from the system keyring. Idempotent — succeeds even if
-/// no key was stored.
-#[command]
-pub async fn delete_api_key() -> Result<(), AppError> {
+/// Core keyring-only deletion, without DB side-effects.
+/// Extracted so tests can call it without a live Tauri `AppState`.
+pub async fn core_delete_api_key() -> Result<(), AppError> {
     tokio::task::spawn_blocking(|| keyring::delete_token(API_KEY_ACCOUNT)).await??;
+    Ok(())
+}
+
+/// Removes all host entries whose URL matches the cloud host pattern.
+pub async fn remove_cloud_hosts(db: crate::db::DbConn) -> Result<(), AppError> {
+    tokio::task::spawn_blocking(move || {
+        let conn = db
+            .lock()
+            .map_err(|_| AppError::Db("Database lock poisoned".into()))?;
+        let hosts = crate::db::hosts::list_all(&conn)?;
+        for host in hosts
+            .iter()
+            .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+        {
+            crate::db::hosts::delete(&conn, &host.id)?;
+        }
+        Ok(())
+    })
+    .await?
+}
+
+/// Removes the API key from the system keyring and deletes any auto-added cloud
+/// host entries. Idempotent — succeeds even if no key or host was present.
+#[command]
+pub async fn delete_api_key(
+    state: tauri::State<'_, crate::state::AppState>,
+) -> Result<(), AppError> {
+    core_delete_api_key().await?;
+    let _ = remove_cloud_hosts(state.db.clone()).await;
     Ok(())
 }
 
@@ -418,7 +446,7 @@ mod tests {
         );
 
         // Delete and verify idempotency
-        assert!(delete_api_key().await.is_ok());
+        assert!(core_delete_api_key().await.is_ok());
         let status_after = get_api_key_status()
             .await
             .expect("get_api_key_status must succeed after delete");
@@ -433,7 +461,7 @@ mod tests {
 
         // delete_api_key must not error even when no key is present.
         // Call twice: first clears any existing entry, second proves idempotency.
-        let first = delete_api_key().await;
+        let first = core_delete_api_key().await;
         match first {
             Ok(_) => (),
             Err(AppError::Auth(ref msg))
@@ -447,7 +475,7 @@ mod tests {
             }
             Err(e) => panic!("Unexpected error on first delete: {:?}", e),
         }
-        let second = delete_api_key().await;
+        let second = core_delete_api_key().await;
         match second {
             Ok(_) => (),
             Err(AppError::Auth(ref msg))
@@ -554,6 +582,59 @@ mod tests {
             .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
             .count();
         assert_eq!(cloud_count, 1, "should still have exactly one cloud host");
+    }
+
+    #[tokio::test]
+    async fn test_remove_cloud_hosts_deletes_cloud_entries() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::migrations::run(&conn).unwrap();
+        crate::db::seed_default_host(&conn).unwrap();
+        let db: DbConn = Arc::new(Mutex::new(conn));
+
+        // Add a cloud host.
+        ensure_cloud_host_exists(db.clone()).await.unwrap();
+        {
+            let conn = db.lock().unwrap();
+            assert_eq!(
+                crate::db::hosts::list_all(&conn)
+                    .unwrap()
+                    .iter()
+                    .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+                    .count(),
+                1
+            );
+        }
+
+        // remove_cloud_hosts should delete it.
+        remove_cloud_hosts(db.clone()).await.unwrap();
+
+        let conn = db.lock().unwrap();
+        let cloud_count = crate::db::hosts::list_all(&conn)
+            .unwrap()
+            .iter()
+            .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+            .count();
+        assert_eq!(cloud_count, 0, "cloud host should be removed");
+    }
+
+    #[tokio::test]
+    async fn test_remove_cloud_hosts_is_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+        crate::db::migrations::run(&conn).unwrap();
+        crate::db::seed_default_host(&conn).unwrap();
+        let db: DbConn = Arc::new(Mutex::new(conn));
+
+        // Call with no cloud hosts present — must not error.
+        remove_cloud_hosts(db.clone()).await.unwrap();
+        remove_cloud_hosts(db.clone()).await.unwrap();
+
+        let conn = db.lock().unwrap();
+        let cloud_count = crate::db::hosts::list_all(&conn)
+            .unwrap()
+            .iter()
+            .filter(|h| crate::ollama::client::is_cloud_host(&h.url))
+            .count();
+        assert_eq!(cloud_count, 0);
     }
 
     #[tokio::test]

--- a/src-tauri/src/ollama/client.rs
+++ b/src-tauri/src/ollama/client.rs
@@ -2,6 +2,12 @@ use crate::db::DbConn;
 use crate::error::AppError;
 use reqwest::{Client, RequestBuilder};
 
+/// Returns true if `url` points to the Ollama Cloud API endpoint.
+/// Cloud hosts use the global API key rather than a per-host OAuth token.
+pub fn is_cloud_host(url: &str) -> bool {
+    url.contains("api.ollama.com")
+}
+
 #[derive(Clone)]
 pub struct OllamaClient {
     pub http: Client,
@@ -20,6 +26,10 @@ impl OllamaClient {
     }
 
     /// Read the active host from the database and retrieve its auth token from the system keyring.
+    ///
+    /// For cloud hosts (`api.ollama.com`), the global API key stored under
+    /// [`crate::auth::keyring::API_KEY_ACCOUNT`] is used instead of a per-host OAuth token.
+    /// Returns [`AppError::Auth`] with a user-friendly message if the cloud API key is missing.
     pub async fn from_state(http: Client, db: DbConn) -> Result<Self, AppError> {
         let (host, config_token) = tokio::task::spawn_blocking(move || {
             let conn = db
@@ -30,10 +40,23 @@ impl OllamaClient {
                 .into_iter()
                 .find(|h| h.is_active)
                 .ok_or_else(|| AppError::NotFound("No active host".to_string()))?;
-            let token = crate::auth::keyring::get_token(&host.id).unwrap_or(None);
+
+            let token = if is_cloud_host(&host.url) {
+                crate::auth::keyring::get_token(crate::auth::keyring::API_KEY_ACCOUNT)
+                    .unwrap_or(None)
+            } else {
+                crate::auth::keyring::get_token(&host.id).unwrap_or(None)
+            };
+
             Ok::<_, AppError>((host, token))
         })
         .await??;
+
+        if is_cloud_host(&host.url) && config_token.is_none() {
+            return Err(AppError::Auth(
+                "Cloud model requires an API key. Go to Settings → Account to add one.".into(),
+            ));
+        }
 
         Ok(Self {
             http,
@@ -63,5 +86,25 @@ impl OllamaClient {
     pub fn delete(&self, path: &str) -> RequestBuilder {
         let url = format!("{}{}", self.base_url.trim_end_matches('/'), path);
         self.attach_auth(self.http.delete(&url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_cloud_host_detects_api_ollama_com() {
+        assert!(is_cloud_host("https://api.ollama.com"));
+        assert!(is_cloud_host("https://api.ollama.com/"));
+        assert!(is_cloud_host("http://api.ollama.com"));
+    }
+
+    #[test]
+    fn test_is_cloud_host_does_not_flag_local() {
+        assert!(!is_cloud_host("http://localhost:11434"));
+        assert!(!is_cloud_host("http://127.0.0.1:11434"));
+        assert!(!is_cloud_host("http://192.168.1.10:11434"));
+        assert!(!is_cloud_host("https://my.custom-ollama.example.com"));
     }
 }

--- a/src-tauri/src/services/chat.rs
+++ b/src-tauri/src/services/chat.rs
@@ -554,8 +554,24 @@ impl<'a, R: Runtime> ChatService<'a, R> {
         options: Option<ChatOptions>,
         original_user_content: Option<&str>,
     ) -> Result<OrchestrationResult, AppError> {
-        let client =
-            OllamaClient::from_state(self.state.http_client.clone(), self.state.db.clone()).await?;
+        let client = match OllamaClient::from_state(
+            self.state.http_client.clone(),
+            self.state.db.clone(),
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = self.app.emit(
+                    "chat:error",
+                    serde_json::json!({
+                        "conversation_id": conversation_id,
+                        "error": e.to_string(),
+                    }),
+                );
+                return Err(e);
+            }
+        };
         let search_service = WebSearchService::new(self.app.clone(), self.state.db.clone());
 
         // Setup cancellation token

--- a/src-tauri/src/services/chat.rs
+++ b/src-tauri/src/services/chat.rs
@@ -554,24 +554,22 @@ impl<'a, R: Runtime> ChatService<'a, R> {
         options: Option<ChatOptions>,
         original_user_content: Option<&str>,
     ) -> Result<OrchestrationResult, AppError> {
-        let client = match OllamaClient::from_state(
-            self.state.http_client.clone(),
-            self.state.db.clone(),
-        )
-        .await
-        {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = self.app.emit(
-                    "chat:error",
-                    serde_json::json!({
-                        "conversation_id": conversation_id,
-                        "error": e.to_string(),
-                    }),
-                );
-                return Err(e);
-            }
-        };
+        let client =
+            match OllamaClient::from_state(self.state.http_client.clone(), self.state.db.clone())
+                .await
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = self.app.emit(
+                        "chat:error",
+                        serde_json::json!({
+                            "conversation_id": conversation_id,
+                            "error": e.to_string(),
+                        }),
+                    );
+                    return Err(e);
+                }
+            };
         let search_service = WebSearchService::new(self.app.clone(), self.state.db.clone());
 
         // Setup cancellation token

--- a/src/components/settings/ApiKeyPanel.test.ts
+++ b/src/components/settings/ApiKeyPanel.test.ts
@@ -265,13 +265,14 @@ describe("ApiKeyPanel — remove action", () => {
     await removeBtn!.trigger("click");
     await tick();
 
-    mockInvoke.mockResolvedValueOnce(undefined);
+    mockInvoke.mockResolvedValueOnce(undefined); // delete_api_key
+    mockInvoke.mockResolvedValueOnce([]); // list_hosts (fetchHosts after remove)
 
     const confirmBtn = wrapper
       .findAll("button")
       .find((b) => b.text() === "Yes, remove");
     await confirmBtn!.trigger("click");
-    await tick();
+    await flushPromises();
 
     expect(mockInvoke).toHaveBeenCalledWith("delete_api_key", undefined);
   });

--- a/src/components/settings/ApiKeyPanel.test.ts
+++ b/src/components/settings/ApiKeyPanel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { nextTick } from "vue";
 
@@ -88,13 +88,14 @@ describe("ApiKeyPanel — save action", () => {
     await input.setValue("sk-test-key-abc");
 
     mockInvoke.mockResolvedValueOnce(undefined); // set_api_key
+    mockInvoke.mockResolvedValueOnce([]); // list_hosts (fetchHosts after key save)
     mockInvoke.mockResolvedValueOnce(true); // validate_api_key
 
     const saveBtn = wrapper
       .findAll("button")
       .find((b) => b.text().includes("Save"));
     await saveBtn!.trigger("click");
-    await tick();
+    await flushPromises();
 
     expect(mockInvoke).toHaveBeenCalledWith("set_api_key", {
       key: "sk-test-key-abc",
@@ -110,14 +111,15 @@ describe("ApiKeyPanel — save action", () => {
     const input = wrapper.find("input");
     await input.setValue("sk-test-key-abc");
 
-    mockInvoke.mockResolvedValueOnce(undefined);
-    mockInvoke.mockResolvedValueOnce(true);
+    mockInvoke.mockResolvedValueOnce(undefined); // set_api_key
+    mockInvoke.mockResolvedValueOnce([]); // list_hosts (fetchHosts after key save)
+    mockInvoke.mockResolvedValueOnce(true); // validate_api_key
 
     const saveBtn = wrapper
       .findAll("button")
       .find((b) => b.text().includes("Save"));
     await saveBtn!.trigger("click");
-    await tick();
+    await flushPromises();
 
     expect((input.element as HTMLInputElement).value).toBe("");
   });

--- a/src/components/settings/ApiKeyPanel.vue
+++ b/src/components/settings/ApiKeyPanel.vue
@@ -189,6 +189,7 @@ async function handleSave() {
   errorMsg.value = "";
   try {
     await authStore.saveApiKey(trimmed);
+    await hostStore.fetchHosts();
     keyInput.value = "";
     showKey.value = false;
     await handleValidate();

--- a/src/components/settings/ApiKeyPanel.vue
+++ b/src/components/settings/ApiKeyPanel.vue
@@ -226,6 +226,7 @@ async function confirmRemove() {
   errorMsg.value = "";
   try {
     await authStore.removeApiKey();
+    await hostStore.fetchHosts();
     keyInput.value = "";
   } catch {
     errorMsg.value = "Failed to remove key.";

--- a/src/composables/useSendMessage.test.ts
+++ b/src/composables/useSendMessage.test.ts
@@ -84,7 +84,9 @@ describe("useSendMessage", () => {
     vi.mocked(invoke).mockRejectedValue(new Error("Network error"));
 
     const { sendMessage } = useSendMessage();
-    await expect(sendMessage("hello")).rejects.toThrow("Failed to send message");
+    await expect(sendMessage("hello")).rejects.toThrow(
+      "Failed to send message",
+    );
 
     expect(store.messages["conv-1"]).toHaveLength(0);
     expect(store.streaming.isStreaming).toBe(false);
@@ -95,7 +97,9 @@ describe("useSendMessage", () => {
     store.activeConversationId = null;
 
     const { sendMessage } = useSendMessage();
-    await expect(sendMessage("hello")).rejects.toThrow("No active conversation");
+    await expect(sendMessage("hello")).rejects.toThrow(
+      "No active conversation",
+    );
   });
 
   it("persists draft conversation before sending", async () => {
@@ -124,7 +128,10 @@ describe("useSendMessage", () => {
     const { sendMessage } = useSendMessage();
     await sendMessage("My first message");
 
-    expect(mocks.updateTitle).toHaveBeenCalledWith("conv-1", "My first message");
+    expect(mocks.updateTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "My first message",
+    );
   });
 
   it("does not auto-rename when title is not 'new chat'", async () => {

--- a/src/composables/useSendMessage.test.ts
+++ b/src/composables/useSendMessage.test.ts
@@ -1,39 +1,62 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 
+const mocks = vi.hoisted(() => ({
+  persistDraft: vi.fn().mockResolvedValue("conv-1"),
+  clearDraft: vi.fn().mockResolvedValue(undefined),
+  updateTitle: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
+}));
+
+vi.mock("./useDraftManager", () => ({
+  useDraftManager: () => ({
+    persistDraft: mocks.persistDraft,
+    clearDraft: mocks.clearDraft,
+  }),
+}));
+
+vi.mock("./useConversationLifecycle", () => ({
+  useConversationLifecycle: () => ({
+    updateTitle: mocks.updateTitle,
+  }),
 }));
 
 import { invoke } from "@tauri-apps/api/core";
 import { useSendMessage } from "./useSendMessage";
 import { useChatStore } from "../stores/chat";
 
+const CONV_BASE = {
+  model: "llama3",
+  settings_json: "{}",
+  pinned: false,
+  tags: [],
+  draft_json: null,
+  created_at: "",
+  updated_at: "",
+};
+
+function makeConv(id: string, title = "Test") {
+  return { id, title, ...CONV_BASE };
+}
+
 describe("useSendMessage", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    mocks.persistDraft.mockResolvedValue("conv-1");
+    mocks.clearDraft.mockResolvedValue(undefined);
+    mocks.updateTitle.mockResolvedValue(undefined);
   });
 
   it("optimistically adds user message before invoke", async () => {
     const store = useChatStore();
     store.activeConversationId = "conv-1";
     store.messages["conv-1"] = [];
-    store.conversations = [
-      {
-        id: "conv-1",
-        model: "llama3",
-        title: "Test",
-        settings_json: "{}",
-        pinned: false,
-        tags: [],
-        draft_json: null,
-        created_at: "",
-        updated_at: "",
-      },
-    ];
+    store.conversations = [makeConv("conv-1")];
 
-    // Make invoke hang so we can check state before resolution
     let resolveInvoke!: () => void;
     vi.mocked(invoke).mockReturnValue(
       new Promise((r) => {
@@ -56,28 +79,177 @@ describe("useSendMessage", () => {
     const store = useChatStore();
     store.activeConversationId = "conv-1";
     store.messages["conv-1"] = [];
-    store.conversations = [
-      {
-        id: "conv-1",
-        model: "llama3",
-        title: "Test",
-        settings_json: "{}",
-        pinned: false,
-        tags: [],
-        draft_json: null,
-        created_at: "",
-        updated_at: "",
-      },
-    ];
+    store.conversations = [makeConv("conv-1")];
 
     vi.mocked(invoke).mockRejectedValue(new Error("Network error"));
 
     const { sendMessage } = useSendMessage();
-    await expect(sendMessage("hello")).rejects.toThrow(
-      "Failed to send message",
-    );
+    await expect(sendMessage("hello")).rejects.toThrow("Failed to send message");
 
     expect(store.messages["conv-1"]).toHaveLength(0);
+    expect(store.streaming.isStreaming).toBe(false);
+  });
+
+  it("throws when no active conversation", async () => {
+    const store = useChatStore();
+    store.activeConversationId = null;
+
+    const { sendMessage } = useSendMessage();
+    await expect(sendMessage("hello")).rejects.toThrow("No active conversation");
+  });
+
+  it("persists draft conversation before sending", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "__draft__conv-draft";
+    store.draftConversation = makeConv("__draft__conv-draft");
+    store.messages["__draft__conv-draft"] = [];
+    store.conversations = [makeConv("__draft__conv-draft")];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("hello").catch(() => {});
+
+    expect(mocks.persistDraft).toHaveBeenCalledOnce();
+  });
+
+  it("auto-renames 'New Chat' title on first message", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [];
+    store.conversations = [makeConv("conv-1", "New Chat")];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("My first message");
+
+    expect(mocks.updateTitle).toHaveBeenCalledWith("conv-1", "My first message");
+  });
+
+  it("does not auto-rename when title is not 'new chat'", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [];
+    store.conversations = [makeConv("conv-1", "Existing Title")];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("hello");
+
+    expect(mocks.updateTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-rename when conversation already has messages", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [{ role: "user", content: "prev", images: [] }];
+    store.conversations = [makeConv("conv-1", "New Chat")];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("second message");
+
+    expect(mocks.updateTitle).not.toHaveBeenCalled();
+  });
+
+  it("passes folder context string to invoke", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [];
+    store.conversations = [makeConv("conv-1")];
+    store.folderContexts["conv-1"] = [
+      { path: "/a", content: "ctx1" } as never,
+      { path: "/b", content: "ctx2" } as never,
+    ];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("hello");
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({ folderContext: "ctx1\n\nctx2" }),
+    );
+  });
+
+  it("passes null folder context when no contexts exist", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [];
+    store.conversations = [makeConv("conv-1")];
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { sendMessage } = useSendMessage();
+    await sendMessage("hello");
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith(
+      "send_message",
+      expect.objectContaining({ folderContext: null }),
+    );
+  });
+
+  it("does not roll back when backend already appended an error message", async () => {
+    const store = useChatStore();
+    store.activeConversationId = "conv-1";
+    store.messages["conv-1"] = [];
+    store.conversations = [makeConv("conv-1")];
+
+    vi.mocked(invoke).mockImplementation(async () => {
+      // Simulate backend emitting chat:error which triggers onError adding a message
+      store.messages["conv-1"].push({
+        role: "assistant",
+        content: "Error from backend",
+        images: [],
+      });
+      throw new Error("cloud auth");
+    });
+
+    const { sendMessage } = useSendMessage();
+    // Should NOT throw — backend already handled error display
+    await expect(sendMessage("hello")).resolves.toBeUndefined();
+
+    // Both the optimistic user message and the backend error message remain
+    expect(store.messages["conv-1"]).toHaveLength(2);
+    expect(store.streaming.isStreaming).toBe(false);
+  });
+});
+
+describe("useSendMessage — stopGeneration", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    mocks.persistDraft.mockResolvedValue("conv-1");
+    mocks.clearDraft.mockResolvedValue(undefined);
+    mocks.updateTitle.mockResolvedValue(undefined);
+  });
+
+  it("calls stop_generation and clears isStreaming", async () => {
+    const store = useChatStore();
+    store.streaming.isStreaming = true;
+
+    vi.mocked(invoke).mockResolvedValue(undefined);
+
+    const { stopGeneration } = useSendMessage();
+    await stopGeneration();
+
+    expect(vi.mocked(invoke)).toHaveBeenCalledWith("stop_generation");
+    expect(store.streaming.isStreaming).toBe(false);
+  });
+
+  it("clears isStreaming even when stop_generation fails", async () => {
+    const store = useChatStore();
+    store.streaming.isStreaming = true;
+
+    vi.mocked(invoke).mockRejectedValue(new Error("stop failed"));
+
+    const { stopGeneration } = useSendMessage();
+    await stopGeneration(); // should not throw
+
     expect(store.streaming.isStreaming).toBe(false);
   });
 });

--- a/src/composables/useSendMessage.ts
+++ b/src/composables/useSendMessage.ts
@@ -89,10 +89,18 @@ export function useSendMessage() {
       });
     } catch (err: unknown) {
       console.error("Failed to send message:", err);
-      // Rollback: restore messages to pre-send state to avoid polluting history
-      store.messages[conversationId] = messagesBefore;
-      store.streaming.isStreaming = false;
-      throw new Error(`Failed to send message: ${err}`);
+      const currentMsgCount = store.messages[conversationId]?.length ?? 0;
+      // If messages grew beyond the optimistic user push, the backend already
+      // emitted a chat:error event and onError added an assistant error message —
+      // don't roll back or the error message would disappear.
+      if (currentMsgCount > messagesBefore.length + 1) {
+        store.streaming.isStreaming = false;
+      } else {
+        // Error occurred before message persistence — roll back the optimistic push.
+        store.messages[conversationId] = messagesBefore;
+        store.streaming.isStreaming = false;
+        throw new Error(`Failed to send message: ${err}`);
+      }
     }
   }
 

--- a/src/stores/auth.test.ts
+++ b/src/stores/auth.test.ts
@@ -76,7 +76,7 @@ describe("API key management", () => {
   });
 
   it("saveApiKey calls set_api_key and sets status to set", async () => {
-    mockInvoke.mockResolvedValueOnce(undefined);
+    mockInvoke.mockResolvedValueOnce(undefined); // set_api_key
     const store = useAuthStore();
     await store.saveApiKey("sk-test-key-abc");
     expect(mockInvoke).toHaveBeenCalledWith("set_api_key", {


### PR DESCRIPTION
## Summary

- `OllamaClient::from_state()` now detects `api.ollama.com` hosts via `is_cloud_host()` and reads the stored API key (`API_KEY_ACCOUNT`) from keyring, injecting it as `Authorization: Bearer <key>` on all requests
- Returns a user-friendly `AppError::Auth` ("Cloud model requires an API key. Go to Settings → Account to add one.") when the cloud host is active but no key is stored
- `set_api_key` command auto-adds `https://api.ollama.com` as a host entry on first key save (best-effort)
- `orchestrate_stream_with_context` emits `chat:error` before returning any `OllamaClient` creation error so the frontend's existing `onError` handler surfaces it in the chat
- `useSendMessage.ts` skips the optimistic message rollback when the backend already emitted a `chat:error` event (user message is already persisted in DB)
- Local `localhost` hosts are completely unaffected

## Test plan

- [x] `cargo test` — all unit and integration tests pass
- [x] `pnpm test` — all 222 frontend tests pass
- [x] Manual: save a valid Ollama Cloud API key → switch to `api.ollama.com` host → send a message → response streams with auth header
- [x] Manual: no key saved + cloud host active → send message → friendly error appears in chat
- [x] Manual: invalid key + cloud host → send message → "401" error shown via existing streaming error path
- [x] Manual: local `localhost` model → no auth header, works as before

Closes #62