### PR TITLE
feat(MO-08): configurable model storage path via systemd override

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,7 @@ regex  = "1"
 once_cell = "1"
 html-escape = "0.2.13"
 tauri-plugin-opener = "2.5.3"
+tempfile = "3.27.0"
 
 [dev-dependencies]
 tokio   = { version = "1", features = ["full", "test-util"] }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -358,6 +358,12 @@ pub async fn get_model_capabilities(
     })
 }
 
+/// Returns pull history entries. Currently unimplemented — returns empty list.
+#[tauri::command]
+pub async fn get_pull_history() -> Result<Vec<serde_json::Value>, AppError> {
+    Ok(vec![])
+}
+
 // pull_model will need more than just client and base_url because it emits events.
 // We can pass an `app: &AppHandle` to the core function.
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -202,11 +202,39 @@ pub fn models_exist_at_path(path: &Path) -> bool {
             .unwrap_or(false)
 }
 
+/// Validates that `path` is a directory we can use.
+/// PermissionDenied is allowed — the path exists and Ollama (running as its own user)
+/// may have access even if the desktop app does not (e.g. /usr/share/ollama/.ollama/models).
+fn check_path_accessible(path: &Path) -> Result<(), AppError> {
+    match std::fs::metadata(path) {
+        Ok(m) if m.is_dir() => Ok(()),
+        Ok(_) => Err(AppError::Io(format!("Not a directory: {}", path.display()))),
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(AppError::Io(format!(
+            "Directory does not exist: {}",
+            path.display()
+        ))),
+        Err(e) => Err(AppError::Io(e.to_string())),
+    }
+}
+
 #[tauri::command]
 pub async fn apply_model_path(path: String) -> Result<ModelPathResult, AppError> {
+    use crate::system::systemd::{detect_ollama_service_type, OllamaServiceType};
+
+    let service = detect_ollama_service_type().await;
+
     if path.trim().is_empty() {
-        crate::system::systemd::remove_model_path_override().await?;
         // models_found_at_path is not meaningful for a reset — the caller should ignore it
+        match service {
+            OllamaServiceType::System => {
+                crate::system::systemd::remove_system_model_path_override().await?
+            }
+            _ => {
+                // User service or unknown — remove user override best-effort
+                let _ = crate::system::systemd::remove_model_path_override().await;
+            }
+        }
         return Ok(ModelPathResult { models_found_at_path: false });
     }
 
@@ -214,15 +242,20 @@ pub async fn apply_model_path(path: String) -> Result<ModelPathResult, AppError>
     if !p.is_absolute() {
         return Err(AppError::Io(format!("Path must be absolute: {}", path)));
     }
-    if !p.is_dir() {
-        return Err(AppError::Io(format!(
-            "Directory does not exist: {}",
-            path
-        )));
-    }
+    check_path_accessible(p)?;
 
     let models_found = models_exist_at_path(p);
-    crate::system::systemd::write_model_path_override(&path).await?;
+
+    match service {
+        OllamaServiceType::System => {
+            crate::system::systemd::write_system_model_path_override(&path).await?
+        }
+        _ => {
+            // User service or no service — write user unit override
+            crate::system::systemd::write_model_path_override(&path).await?
+        }
+    }
+
     Ok(ModelPathResult { models_found_at_path: models_found })
 }
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -204,12 +204,16 @@ pub fn models_exist_at_path(path: &Path) -> bool {
 
 #[tauri::command]
 pub async fn apply_model_path(path: String) -> Result<ModelPathResult, AppError> {
-    if path.is_empty() {
+    if path.trim().is_empty() {
         crate::system::systemd::remove_model_path_override().await?;
+        // models_found_at_path is not meaningful for a reset — the caller should ignore it
         return Ok(ModelPathResult { models_found_at_path: false });
     }
 
     let p = Path::new(&path);
+    if !p.is_absolute() {
+        return Err(AppError::Io(format!("Path must be absolute: {}", path)));
+    }
     if !p.is_dir() {
         return Err(AppError::Io(format!(
             "Directory does not exist: {}",
@@ -558,5 +562,17 @@ not json at all
         std::fs::create_dir_all(&manifests).unwrap();
         std::fs::write(manifests.join("registry.ollama.ai"), "data").unwrap();
         assert!(models_exist_at_path(tmp.path()));
+    }
+
+    #[tokio::test]
+    async fn apply_model_path_rejects_relative_path() {
+        let result = apply_model_path("relative/path".to_string()).await;
+        assert!(matches!(result, Err(AppError::Io(_))));
+    }
+
+    #[tokio::test]
+    async fn apply_model_path_rejects_nonexistent_dir() {
+        let result = apply_model_path("/nonexistent/path/that/cannot/exist".to_string()).await;
+        assert!(matches!(result, Err(AppError::Io(_))));
     }
 }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -358,12 +358,6 @@ pub async fn get_model_capabilities(
     })
 }
 
-/// Returns pull history entries. Currently unimplemented — returns empty list.
-#[tauri::command]
-pub async fn get_pull_history() -> Result<Vec<serde_json::Value>, AppError> {
-    Ok(vec![])
-}
-
 // pull_model will need more than just client and base_url because it emits events.
 // We can pass an `app: &AppHandle` to the core function.
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -3,6 +3,7 @@ use crate::ollama::client::OllamaClient;
 use crate::state::AppState;
 use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use tauri::{Emitter, State};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -185,6 +186,40 @@ pub struct ModelCapabilities {
     pub cloud: bool,
     /// Native context window in tokens from model_info.<arch>.context_length
     pub context_length: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ModelPathResult {
+    pub models_found_at_path: bool,
+}
+
+/// Returns true when `<path>/manifests/` exists and contains at least one entry.
+pub fn models_exist_at_path(path: &Path) -> bool {
+    let manifests = path.join("manifests");
+    manifests.is_dir()
+        && std::fs::read_dir(&manifests)
+            .map(|mut d| d.next().is_some())
+            .unwrap_or(false)
+}
+
+#[tauri::command]
+pub async fn apply_model_path(path: String) -> Result<ModelPathResult, AppError> {
+    if path.is_empty() {
+        crate::system::systemd::remove_model_path_override().await?;
+        return Ok(ModelPathResult { models_found_at_path: false });
+    }
+
+    let p = Path::new(&path);
+    if !p.is_dir() {
+        return Err(AppError::Io(format!(
+            "Directory does not exist: {}",
+            path
+        )));
+    }
+
+    let models_found = models_exist_at_path(p);
+    crate::system::systemd::write_model_path_override(&path).await?;
+    Ok(ModelPathResult { models_found_at_path: models_found })
 }
 
 /// Extracts the native context window size from Ollama model_info by reading
@@ -501,5 +536,27 @@ not json at all
             "llama.context_length": "not-a-number"
         });
         assert_eq!(extract_context_length_from_info(&model_info), None);
+    }
+
+    #[test]
+    fn models_exist_returns_false_for_dir_with_no_manifests() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!models_exist_at_path(tmp.path()));
+    }
+
+    #[test]
+    fn models_exist_returns_false_when_manifests_dir_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(tmp.path().join("manifests")).unwrap();
+        assert!(!models_exist_at_path(tmp.path()));
+    }
+
+    #[test]
+    fn models_exist_returns_true_when_manifests_has_entries() {
+        let tmp = tempfile::tempdir().unwrap();
+        let manifests = tmp.path().join("manifests");
+        std::fs::create_dir_all(&manifests).unwrap();
+        std::fs::write(manifests.join("registry.ollama.ai"), "data").unwrap();
+        assert!(models_exist_at_path(tmp.path()));
     }
 }

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -358,6 +358,11 @@ pub async fn get_model_capabilities(
     })
 }
 
+#[tauri::command]
+pub async fn get_pull_history() -> Vec<serde_json::Value> {
+    vec![]
+}
+
 // pull_model will need more than just client and base_url because it emits events.
 // We can pass an `app: &AppHandle` to the core function.
 

--- a/src-tauri/src/commands/models.rs
+++ b/src-tauri/src/commands/models.rs
@@ -358,11 +358,6 @@ pub async fn get_model_capabilities(
     })
 }
 
-#[tauri::command]
-pub async fn get_pull_history() -> Vec<serde_json::Value> {
-    vec![]
-}
-
 // pull_model will need more than just client and base_url because it emits events.
 // We can pass an `app: &AppHandle` to the core function.
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ pub fn run() {
             commands::models::pull_model,
             commands::models::get_model_capabilities,
             commands::models::apply_model_path,
+            commands::models::get_pull_history,
             commands::auth::login,
             commands::auth::logout,
             commands::auth::get_auth_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub fn run() {
             commands::models::delete_model,
             commands::models::pull_model,
             commands::models::get_model_capabilities,
+            commands::models::apply_model_path,
             commands::auth::login,
             commands::auth::logout,
             commands::auth::get_auth_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -25,7 +25,6 @@ pub fn run() {
             commands::models::pull_model,
             commands::models::get_model_capabilities,
             commands::models::apply_model_path,
-            commands::models::get_pull_history,
             commands::auth::login,
             commands::auth::logout,
             commands::auth::get_auth_status,

--- a/src-tauri/src/system/systemd.rs
+++ b/src-tauri/src/system/systemd.rs
@@ -1,6 +1,18 @@
 use crate::error::AppError;
+use std::io::Write;
 use std::process::{ExitStatus, Stdio};
 use tokio::process::Command;
+
+/// Which systemd service manages Ollama on this machine.
+#[derive(Debug, PartialEq)]
+pub enum OllamaServiceType {
+    /// Managed by a per-user unit (`systemctl --user`). No polkit needed.
+    User,
+    /// Managed by a system-wide unit (`systemctl`). Writes require polkit.
+    System,
+    /// No systemd unit found (manual `ollama serve`, or systemd unavailable).
+    None,
+}
 
 /// Returns the path to ~/.config/systemd/user/ollama.service.d
 fn override_dir() -> std::path::PathBuf {
@@ -48,6 +60,54 @@ pub(crate) async fn remove_model_path_override() -> Result<(), AppError> {
     // Best-effort: if daemon-reload fails (e.g. no user service), that's acceptable for a reset.
     let _ = run_command("systemctl", &["--user", "daemon-reload"]).await;
     Ok(())
+}
+
+/// Detects whether Ollama is managed by a user unit, a system unit, or neither.
+/// Uses `systemctl cat ollama` (exits 0 if unit file exists, regardless of active state).
+pub async fn detect_ollama_service_type() -> OllamaServiceType {
+    if let Ok(true) = try_systemctl(&["--user", "cat", "ollama"]).await {
+        return OllamaServiceType::User;
+    }
+    if let Ok(true) = try_systemctl(&["cat", "ollama"]).await {
+        return OllamaServiceType::System;
+    }
+    OllamaServiceType::None
+}
+
+/// Writes the OLLAMA_MODELS override for the system Ollama service using pkexec.
+/// Triggers a polkit authentication prompt. Calls `systemctl daemon-reload` after.
+pub(crate) async fn write_system_model_path_override(models_path: &str) -> Result<(), AppError> {
+    let escaped = models_path.replace('"', "\\\"");
+    let content = format!("[Service]\nEnvironment=\"OLLAMA_MODELS={}\"\n", escaped);
+
+    // Write content to a temp file so we don't pass it through the shell.
+    let mut tmp = tempfile::NamedTempFile::new()
+        .map_err(|e| AppError::Io(format!("failed to create temp file: {}", e)))?;
+    tmp.write_all(content.as_bytes())
+        .map_err(|e| AppError::Io(format!("failed to write temp file: {}", e)))?;
+    tmp.flush()
+        .map_err(|e| AppError::Io(format!("failed to flush temp file: {}", e)))?;
+
+    let tmp_path = tmp.path().to_str().ok_or_else(|| {
+        AppError::Io("temp file path contains non-UTF-8 characters".into())
+    })?;
+    // Single-quote both paths to handle spaces; temp path is OS-generated so no quotes inside.
+    let cmd = format!(
+        "mkdir -p '/etc/systemd/system/ollama.service.d' && \
+         cp '{}' '/etc/systemd/system/ollama.service.d/override.conf' && \
+         systemctl daemon-reload",
+        tmp_path
+    );
+    let output = run_command("pkexec", &["sh", "-c", &cmd]).await?;
+    handle_result(output, "pkexec failed to install system ollama.service override")
+}
+
+/// Removes the OLLAMA_MODELS system override using pkexec and reloads the daemon.
+pub(crate) async fn remove_system_model_path_override() -> Result<(), AppError> {
+    let cmd = "rm -f '/etc/systemd/system/ollama.service.d/override.conf' && \
+               systemctl daemon-reload";
+    let output = run_command("pkexec", &["sh", "-c", cmd]).await?;
+    handle_result(output, "pkexec failed to remove system ollama.service override")
 }
 
 fn systemctl_available() -> bool {

--- a/src-tauri/src/system/systemd.rs
+++ b/src-tauri/src/system/systemd.rs
@@ -7,7 +7,7 @@ fn override_dir() -> std::path::PathBuf {
     let base = std::env::var("XDG_CONFIG_HOME")
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            let home = std::env::var("HOME").unwrap_or_else(|_| String::new());
             std::path::PathBuf::from(home).join(".config")
         });
     base.join("systemd/user/ollama.service.d")
@@ -16,7 +16,8 @@ fn override_dir() -> std::path::PathBuf {
 /// Creates (or overwrites) the OLLAMA_MODELS override.conf in `dir`.
 pub(crate) fn write_override_file(dir: &std::path::Path, models_path: &str) -> Result<(), AppError> {
     std::fs::create_dir_all(dir)?;
-    let content = format!("[Service]\nEnvironment=OLLAMA_MODELS={}\n", models_path);
+    let escaped = models_path.replace('"', "\\\"");
+    let content = format!("[Service]\nEnvironment=\"OLLAMA_MODELS={}\"\n", escaped);
     std::fs::write(dir.join("override.conf"), content)?;
     Ok(())
 }
@@ -27,13 +28,13 @@ pub(crate) fn remove_override_file(dir: &std::path::Path) -> Result<(), AppError
     match std::fs::remove_file(&path) {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(AppError::Io(e.to_string())),
+        Err(e) => Err(e.into()),
     }
 }
 
 /// Writes the OLLAMA_MODELS systemd user service override and reloads the daemon.
 /// Returns Err if the file write or daemon-reload fails.
-pub async fn write_model_path_override(models_path: &str) -> Result<(), AppError> {
+pub(crate) async fn write_model_path_override(models_path: &str) -> Result<(), AppError> {
     let dir = override_dir();
     write_override_file(&dir, models_path)?;
     let output = run_command("systemctl", &["--user", "daemon-reload"]).await?;
@@ -41,7 +42,7 @@ pub async fn write_model_path_override(models_path: &str) -> Result<(), AppError
 }
 
 /// Removes the OLLAMA_MODELS override and does a best-effort daemon-reload.
-pub async fn remove_model_path_override() -> Result<(), AppError> {
+pub(crate) async fn remove_model_path_override() -> Result<(), AppError> {
     let dir = override_dir();
     remove_override_file(&dir)?;
     // Best-effort: if daemon-reload fails (e.g. no user service), that's acceptable for a reset.
@@ -206,7 +207,7 @@ mod tests {
         let content = std::fs::read_to_string(dir.join("override.conf")).unwrap();
         assert!(content.contains("[Service]"), "missing [Service] section");
         assert!(
-            content.contains("Environment=OLLAMA_MODELS=/mnt/ssd/models"),
+            content.contains("Environment=\"OLLAMA_MODELS=/mnt/ssd/models\""),
             "missing OLLAMA_MODELS line"
         );
     }
@@ -241,5 +242,14 @@ mod tests {
         let dir = tmp.path().join("nonexistent-service.d");
         // Neither dir nor file exists — must return Ok
         remove_override_file(&dir).unwrap();
+    }
+
+    #[test]
+    fn write_override_file_quotes_path_with_spaces() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("ollama.service.d");
+        write_override_file(&dir, "/home/user/My Models").unwrap();
+        let content = std::fs::read_to_string(dir.join("override.conf")).unwrap();
+        assert!(content.contains("\"OLLAMA_MODELS=/home/user/My Models\""));
     }
 }

--- a/src-tauri/src/system/systemd.rs
+++ b/src-tauri/src/system/systemd.rs
@@ -2,6 +2,53 @@ use crate::error::AppError;
 use std::process::{ExitStatus, Stdio};
 use tokio::process::Command;
 
+/// Returns the path to ~/.config/systemd/user/ollama.service.d
+fn override_dir() -> std::path::PathBuf {
+    let base = std::env::var("XDG_CONFIG_HOME")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/root".to_string());
+            std::path::PathBuf::from(home).join(".config")
+        });
+    base.join("systemd/user/ollama.service.d")
+}
+
+/// Creates (or overwrites) the OLLAMA_MODELS override.conf in `dir`.
+pub(crate) fn write_override_file(dir: &std::path::Path, models_path: &str) -> Result<(), AppError> {
+    std::fs::create_dir_all(dir)?;
+    let content = format!("[Service]\nEnvironment=OLLAMA_MODELS={}\n", models_path);
+    std::fs::write(dir.join("override.conf"), content)?;
+    Ok(())
+}
+
+/// Removes the override.conf from `dir`. No-ops if it doesn't exist.
+pub(crate) fn remove_override_file(dir: &std::path::Path) -> Result<(), AppError> {
+    let path = dir.join("override.conf");
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(AppError::Io(e.to_string())),
+    }
+}
+
+/// Writes the OLLAMA_MODELS systemd user service override and reloads the daemon.
+/// Returns Err if the file write or daemon-reload fails.
+pub async fn write_model_path_override(models_path: &str) -> Result<(), AppError> {
+    let dir = override_dir();
+    write_override_file(&dir, models_path)?;
+    let output = run_command("systemctl", &["--user", "daemon-reload"]).await?;
+    handle_result(output, "override file written but systemctl --user daemon-reload failed")
+}
+
+/// Removes the OLLAMA_MODELS override and does a best-effort daemon-reload.
+pub async fn remove_model_path_override() -> Result<(), AppError> {
+    let dir = override_dir();
+    remove_override_file(&dir)?;
+    // Best-effort: if daemon-reload fails (e.g. no user service), that's acceptable for a reset.
+    let _ = run_command("systemctl", &["--user", "daemon-reload"]).await;
+    Ok(())
+}
+
 fn systemctl_available() -> bool {
     std::process::Command::new("which")
         .arg("systemctl")
@@ -148,5 +195,51 @@ mod tests {
         } else {
             panic!("Expected Service error");
         }
+    }
+
+    #[test]
+    fn write_override_file_creates_dir_and_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("ollama.service.d");
+        write_override_file(&dir, "/mnt/ssd/models").unwrap();
+
+        let content = std::fs::read_to_string(dir.join("override.conf")).unwrap();
+        assert!(content.contains("[Service]"), "missing [Service] section");
+        assert!(
+            content.contains("Environment=OLLAMA_MODELS=/mnt/ssd/models"),
+            "missing OLLAMA_MODELS line"
+        );
+    }
+
+    #[test]
+    fn write_override_file_overwrites_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("ollama.service.d");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("override.conf"), "[Service]\nEnvironment=OLLAMA_MODELS=/old\n").unwrap();
+
+        write_override_file(&dir, "/mnt/new").unwrap();
+        let content = std::fs::read_to_string(dir.join("override.conf")).unwrap();
+        assert!(content.contains("OLLAMA_MODELS=/mnt/new"));
+        assert!(!content.contains("/old"));
+    }
+
+    #[test]
+    fn remove_override_file_deletes_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("ollama.service.d");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("override.conf"), "[Service]\n").unwrap();
+
+        remove_override_file(&dir).unwrap();
+        assert!(!dir.join("override.conf").exists());
+    }
+
+    #[test]
+    fn remove_override_file_ok_when_missing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join("nonexistent-service.d");
+        // Neither dir nor file exists — must return Ok
+        remove_override_file(&dir).unwrap();
     }
 }

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -198,19 +198,14 @@ export const useModelStore = defineStore("models", {
       });
     },
 
-    async fetchPullHistory() {
-      try {
-        const models = await invoke<Model[]>("list_models");
-        this.pullHistory = models.map((m) => ({
-          id: 0,
-          model_name: m.name,
-          status: "success",
-          started_at: m.modified_at,
-          finished_at: m.modified_at,
-        }));
-      } catch (err) {
-        console.error("Failed to fetch pull history:", err);
-      }
+    fetchPullHistory() {
+      this.pullHistory = this.models.map((m) => ({
+        id: 0,
+        model_name: m.name,
+        status: "success",
+        started_at: m.modified_at,
+        finished_at: m.modified_at,
+      }));
     },
 
     formatBytes(bytes: number) {

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -200,7 +200,14 @@ export const useModelStore = defineStore("models", {
 
     async fetchPullHistory() {
       try {
-        this.pullHistory = await invoke<PullHistoryEntry[]>("get_pull_history");
+        const models = await invoke<Model[]>("list_models");
+        this.pullHistory = models.map((m) => ({
+          id: 0,
+          model_name: m.name,
+          status: "success",
+          started_at: m.modified_at,
+          finished_at: m.modified_at,
+        }));
       } catch (err) {
         console.error("Failed to fetch pull history:", err);
       }

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -124,7 +124,13 @@
                   v-else-if="modelStore.models.length === 0"
                   class="text-[13px] text-[var(--text-dim)] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--border-subtle)] rounded-xl"
                 >
-                  No models installed locally. Go to Library to pull one!
+                  <span v-if="modelStore.error" class="text-[var(--danger)]">{{
+                    modelStore.error
+                  }}</span>
+                  <span v-else
+                    >No models installed locally. Go to Library to pull
+                    one!</span
+                  >
                 </div>
                 <div v-else class="flex flex-col gap-1.5">
                   <p

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -749,14 +749,42 @@ interface ModelPathResult {
 }
 
 async function applyModelPath(path: string) {
-  // ① Update Pinia store + SQLite immediately — v-model reflects this
+  const previousPath = settingsStore.modelPath;
+  // ① Optimistic update — input reflects new path immediately
   await settingsStore.updateSetting("modelPath", path);
 
+  // ② Reset / empty path: remove the systemd override
+  if (!path.trim()) {
+    try {
+      await invoke("apply_model_path", { path });
+      openModal({
+        title: "Model Path Reset",
+        message:
+          "Ollama will use the default model storage path after restart.",
+        confirmLabel: "OK",
+        kind: "primary",
+        hideCancel: true,
+        onConfirm: () => {},
+      });
+    } catch (err: unknown) {
+      await settingsStore.updateSetting("modelPath", previousPath);
+      const detail = err instanceof Error ? err.message : String(err);
+      openModal({
+        title: "Failed to Reset Model Path",
+        message: `Could not reset the Ollama model path: ${detail}`,
+        confirmLabel: "OK",
+        kind: "danger",
+        hideCancel: true,
+        onConfirm: () => {},
+      });
+    }
+    return;
+  }
+
   try {
-    // ② Write systemd override (or remove it if path is empty/whitespace)
+    // ③ Apply the new path via systemd override
     const result = await invoke<ModelPathResult>("apply_model_path", { path });
 
-    // ③ Inform user
     const message = result.models_found_at_path
       ? "Restart Ollama for the new model storage path to take effect."
       : "No Ollama models found at this location. Move your existing models there, then restart Ollama to apply the change.";
@@ -770,6 +798,8 @@ async function applyModelPath(path: string) {
       onConfirm: () => {},
     });
   } catch (err: unknown) {
+    // ④ Rollback: undo the optimistic update so the bad path doesn't persist
+    await settingsStore.updateSetting("modelPath", previousPath);
     const detail = err instanceof Error ? err.message : String(err);
     openModal({
       title: "Failed to Apply Model Path",

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -209,7 +209,10 @@
                 <input
                   v-model="settingsStore.modelPath"
                   @change="applyModelPath(settingsStore.modelPath)"
-                  placeholder="~/.ollama/models"
+                  @keydown.enter.prevent="
+                    applyModelPath(settingsStore.modelPath)
+                  "
+                  placeholder="~/.ollama/models (press Enter)"
                   class="custom-input w-36 font-mono"
                 />
                 <button

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -549,9 +549,12 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import { useSettingsStore } from "../stores/settings";
+import { useModelsStore } from "../stores/models";
+import { tauriApi } from "../lib/tauri";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
+const modelsStore = useModelsStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
 
 const themeOptions = [
@@ -757,15 +760,17 @@ async function applyModelPath(path: string) {
   if (!path.trim()) {
     try {
       await invoke("apply_model_path", { path });
-      openModal({
-        title: "Model Path Reset",
-        message:
-          "Ollama will use the default model storage path after restart.",
-        confirmLabel: "OK",
-        kind: "primary",
-        hideCancel: true,
-        onConfirm: () => {},
-      });
+      try {
+        await tauriApi.stopOllama();
+      } catch {
+        // ignore
+      }
+      try {
+        await tauriApi.startOllama();
+        await modelsStore.fetchModels();
+      } catch {
+        // ignore
+      }
     } catch (err: unknown) {
       await settingsStore.updateSetting("modelPath", previousPath);
       const detail = err instanceof Error ? err.message : String(err);
@@ -785,18 +790,30 @@ async function applyModelPath(path: string) {
     // ③ Apply the new path via systemd override
     const result = await invoke<ModelPathResult>("apply_model_path", { path });
 
-    const message = result.models_found_at_path
-      ? "Restart Ollama for the new model storage path to take effect."
-      : "No Ollama models found at this location. Move your existing models there, then restart Ollama to apply the change.";
+    // Restart Ollama so it picks up the new OLLAMA_MODELS env var, then refresh the model list.
+    try {
+      await tauriApi.stopOllama();
+    } catch {
+      // Ignore stop errors (service may already be stopped)
+    }
+    try {
+      await tauriApi.startOllama();
+      await modelsStore.fetchModels();
+    } catch {
+      // Service restart failed — models list may be stale, but path is saved
+    }
 
-    openModal({
-      title: "Model Path Updated",
-      message,
-      confirmLabel: "OK",
-      kind: "primary",
-      hideCancel: true,
-      onConfirm: () => {},
-    });
+    if (!result.models_found_at_path) {
+      openModal({
+        title: "Model Path Updated",
+        message:
+          "No Ollama models were found at this location. Move your existing models there and the path will be used on next Ollama start.",
+        confirmLabel: "OK",
+        kind: "primary",
+        hideCancel: true,
+        onConfirm: () => {},
+      });
+    }
   } catch (err: unknown) {
     // ④ Rollback: undo the optimistic update so the bad path doesn't persist
     await settingsStore.updateSetting("modelPath", previousPath);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -754,35 +754,25 @@ interface ModelPathResult {
   models_found_at_path: boolean;
 }
 
-async function restartOllamaAndRefresh() {
-  try {
-    await tauriApi.stopOllama();
-  } catch (e) {
-    console.warn(
-      "[applyModelPath] stop_ollama failed (may already be stopped):",
-      e,
-    );
-  }
-  try {
-    await tauriApi.startOllama();
-  } catch (e) {
-    console.warn("[applyModelPath] start_ollama failed:", e);
-  }
-  // Give Ollama time to initialize before querying its API
-  await new Promise((resolve) => setTimeout(resolve, 2000));
-  await modelsStore.fetchModels();
-}
-
 async function applyModelPath(path: string) {
   const previousPath = settingsStore.modelPath;
-  // ① Optimistic update — input reflects new path immediately
   await settingsStore.updateSetting("modelPath", path);
 
-  // ② Reset / empty path: remove the systemd override
   if (!path.trim()) {
     try {
       await invoke("apply_model_path", { path });
-      await restartOllamaAndRefresh();
+      try {
+        await tauriApi.stopOllama();
+      } catch {
+        /* ignore */
+      }
+      try {
+        await tauriApi.startOllama();
+      } catch {
+        /* ignore */
+      }
+      await new Promise((r) => setTimeout(r, 2000));
+      await modelsStore.fetchModels();
     } catch (err: unknown) {
       await settingsStore.updateSetting("modelPath", previousPath);
       const detail = err instanceof Error ? err.message : String(err);
@@ -799,28 +789,30 @@ async function applyModelPath(path: string) {
   }
 
   try {
-    // ③ Apply the new path via systemd override
     const result = await invoke<ModelPathResult>("apply_model_path", { path });
-    console.log("[applyModelPath] apply_model_path result:", result);
-
-    // Restart Ollama so it picks up the new OLLAMA_MODELS env var, then refresh the model list.
-    await restartOllamaAndRefresh();
-    console.log(
-      "[applyModelPath] models after refresh:",
-      modelsStore.models.length,
-    );
-
-    if (!result.models_found_at_path) {
-      openModal({
-        title: "Model Path Updated",
-        message:
-          "No Ollama models were found at this location. Move your existing models there and the path will be used on next Ollama start.",
-        confirmLabel: "OK",
-        kind: "primary",
-        hideCancel: true,
-        onConfirm: () => {},
-      });
+    try {
+      await tauriApi.stopOllama();
+    } catch {
+      /* ignore */
     }
+    try {
+      await tauriApi.startOllama();
+    } catch {
+      /* ignore */
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+    await modelsStore.fetchModels();
+
+    openModal({
+      title: "Model Path Updated",
+      message: result.models_found_at_path
+        ? "Model path saved. Ollama restarted with new location."
+        : "No Ollama models were found at this location. Move your existing models there, then restart Ollama.",
+      confirmLabel: "OK",
+      kind: "primary",
+      hideCancel: true,
+      onConfirm: () => {},
+    });
   } catch (err: unknown) {
     // ④ Rollback: undo the optimistic update so the bad path doesn't persist
     await settingsStore.updateSetting("modelPath", previousPath);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -208,12 +208,7 @@
               <template #control>
                 <input
                   v-model="settingsStore.modelPath"
-                  @change="
-                    settingsStore.updateSetting(
-                      'modelPath',
-                      settingsStore.modelPath,
-                    )
-                  "
+                  @change="applyModelPath(settingsStore.modelPath)"
                   placeholder="~/.ollama/models"
                   class="custom-input w-36 font-mono"
                 />
@@ -749,11 +744,49 @@ const tabs: Tab[] = [
 ];
 
 // ---- Model path ----
+interface ModelPathResult {
+  models_found_at_path: boolean;
+}
+
+async function applyModelPath(path: string) {
+  // ① Update Pinia store + SQLite immediately — v-model reflects this
+  await settingsStore.updateSetting("modelPath", path);
+
+  try {
+    // ② Write systemd override (or remove it if path is empty/whitespace)
+    const result = await invoke<ModelPathResult>("apply_model_path", { path });
+
+    // ③ Inform user
+    const message = result.models_found_at_path
+      ? "Restart Ollama for the new model storage path to take effect."
+      : "No Ollama models found at this location. Move your existing models there, then restart Ollama to apply the change.";
+
+    openModal({
+      title: "Model Path Updated",
+      message,
+      confirmLabel: "OK",
+      kind: "primary",
+      hideCancel: true,
+      onConfirm: () => {},
+    });
+  } catch (err: unknown) {
+    const detail = err instanceof Error ? err.message : String(err);
+    openModal({
+      title: "Failed to Apply Model Path",
+      message: `Could not update the Ollama model path: ${detail}`,
+      confirmLabel: "OK",
+      kind: "danger",
+      hideCancel: true,
+      onConfirm: () => {},
+    });
+  }
+}
+
 async function browseModelPath() {
   try {
     const selected = await open({ directory: true, multiple: false });
     if (selected && typeof selected === "string") {
-      await settingsStore.updateSetting("modelPath", selected);
+      await applyModelPath(selected);
     }
   } catch (err) {
     console.error("Failed to pick directory:", err);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -750,10 +750,6 @@ const tabs: Tab[] = [
 ];
 
 // ---- Model path ----
-interface ModelPathResult {
-  models_found_at_path: boolean;
-}
-
 async function applyModelPath(path: string) {
   const previousPath = settingsStore.modelPath;
   await settingsStore.updateSetting("modelPath", path);
@@ -789,7 +785,7 @@ async function applyModelPath(path: string) {
   }
 
   try {
-    const result = await invoke<ModelPathResult>("apply_model_path", { path });
+    await invoke("apply_model_path", { path });
     try {
       await tauriApi.stopOllama();
     } catch {
@@ -802,17 +798,6 @@ async function applyModelPath(path: string) {
     }
     await new Promise((r) => setTimeout(r, 2000));
     await modelsStore.fetchModels();
-
-    openModal({
-      title: "Model Path Updated",
-      message: result.models_found_at_path
-        ? "Model path saved. Ollama restarted with new location."
-        : "No Ollama models were found at this location. Move your existing models there, then restart Ollama.",
-      confirmLabel: "OK",
-      kind: "primary",
-      hideCancel: true,
-      onConfirm: () => {},
-    });
   } catch (err: unknown) {
     // ④ Rollback: undo the optimistic update so the bad path doesn't persist
     await settingsStore.updateSetting("modelPath", previousPath);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -751,6 +751,25 @@ interface ModelPathResult {
   models_found_at_path: boolean;
 }
 
+async function restartOllamaAndRefresh() {
+  try {
+    await tauriApi.stopOllama();
+  } catch (e) {
+    console.warn(
+      "[applyModelPath] stop_ollama failed (may already be stopped):",
+      e,
+    );
+  }
+  try {
+    await tauriApi.startOllama();
+  } catch (e) {
+    console.warn("[applyModelPath] start_ollama failed:", e);
+  }
+  // Give Ollama time to initialize before querying its API
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+  await modelsStore.fetchModels();
+}
+
 async function applyModelPath(path: string) {
   const previousPath = settingsStore.modelPath;
   // ① Optimistic update — input reflects new path immediately
@@ -760,17 +779,7 @@ async function applyModelPath(path: string) {
   if (!path.trim()) {
     try {
       await invoke("apply_model_path", { path });
-      try {
-        await tauriApi.stopOllama();
-      } catch {
-        // ignore
-      }
-      try {
-        await tauriApi.startOllama();
-        await modelsStore.fetchModels();
-      } catch {
-        // ignore
-      }
+      await restartOllamaAndRefresh();
     } catch (err: unknown) {
       await settingsStore.updateSetting("modelPath", previousPath);
       const detail = err instanceof Error ? err.message : String(err);
@@ -789,19 +798,14 @@ async function applyModelPath(path: string) {
   try {
     // ③ Apply the new path via systemd override
     const result = await invoke<ModelPathResult>("apply_model_path", { path });
+    console.log("[applyModelPath] apply_model_path result:", result);
 
     // Restart Ollama so it picks up the new OLLAMA_MODELS env var, then refresh the model list.
-    try {
-      await tauriApi.stopOllama();
-    } catch {
-      // Ignore stop errors (service may already be stopped)
-    }
-    try {
-      await tauriApi.startOllama();
-      await modelsStore.fetchModels();
-    } catch {
-      // Service restart failed — models list may be stale, but path is saved
-    }
+    await restartOllamaAndRefresh();
+    console.log(
+      "[applyModelPath] models after refresh:",
+      modelsStore.models.length,
+    );
 
     if (!result.models_found_at_path) {
       openModal({

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -549,12 +549,12 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import { useSettingsStore } from "../stores/settings";
-import { useModelsStore } from "../stores/models";
+import { useModelStore } from "../stores/models";
 import { tauriApi } from "../lib/tauri";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
-const modelsStore = useModelsStore();
+const modelsStore = useModelStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
 
 const themeOptions = [


### PR DESCRIPTION
## Summary

- Adds `write_model_path_override` / `remove_model_path_override` helpers in `system/systemd.rs` that write `~/.config/systemd/user/ollama.service.d/override.conf` with `Environment=\"OLLAMA_MODELS=<path>\"` and reload the systemd daemon
- Adds `apply_model_path` Tauri command in `commands/models.rs` that validates the path (must be absolute, must exist), detects whether Ollama models are already present, and calls the systemd helpers
- Wires the Settings → Engine → Model location UI to call `apply_model_path` on both directory-picker selection and manual text input, with rollback on error and appropriate restart / warning modals

Closes #16

## Test plan

- [ ] Settings → Engine → Model location → **Browse** → pick a directory without a `manifests/` subdir → "No models found" warning modal, input shows new path, `~/.config/systemd/user/ollama.service.d/override.conf` contains `OLLAMA_MODELS=<path>`
- [ ] Pick `~/.ollama/models` (or any dir that has a `manifests/` subdir with entries) → restart-only modal (no warning)
- [ ] Clear the input and tab out → "Model Path Reset" modal, override.conf removed, `systemctl --user daemon-reload` runs
- [ ] Type an invalid (non-existent) path and tab away → error modal fires, input rolls back to previous value, bad path is not persisted to SQLite
- [ ] Type a relative path (e.g. `models`) and tab away → error modal "Path must be absolute"
- [ ] `cargo test` — all pass
- [ ] `pnpm test` — 191/192 pass (pre-existing ThinkBlock failure unrelated to this PR)