### PR TITLE
feat(model-path): MO-08 configurable Ollama model storage path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- MO-08: Configurable Ollama model storage path — Settings Engine tab writes a systemd service override (`OLLAMA_MODELS`) and restarts Ollama on save; user service handled automatically, system service via pkexec; live path validation with model count and accessibility feedback
 - CL-05: Ollama Cloud routing — stored API key is now injected as `Authorization: Bearer` on all requests to `api.ollama.com` hosts. Missing key surfaces a friendly error in the chat rather than a raw network failure. Saving a key for the first time auto-adds the Ollama Cloud host entry.
 
 ### Changed

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod chat;
 pub mod folders;
 pub mod hosts;
 pub mod library;
+pub mod model_path;
 pub mod models;
 pub mod service;
 pub mod settings;

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -88,6 +88,32 @@ pub fn override_file_content(resolved_path: &str) -> String {
     format!("[Service]\nEnvironment=\"OLLAMA_MODELS={resolved_path}\"\n")
 }
 
+// ── Commands ───────────────────────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn validate_model_path(path: String) -> Result<ModelPathInfo, AppError> {
+    tokio::task::spawn_blocking(move || {
+        let resolved = expand_tilde(&path);
+        let resolved_str = resolved.to_string_lossy().to_string();
+        let exists = resolved.is_dir();
+        let (accessible, model_count) = if exists {
+            match std::fs::read_dir(&resolved) {
+                Ok(_) => (true, count_models(&resolved)),
+                Err(_) => (false, 0),
+            }
+        } else {
+            (false, 0)
+        };
+        Ok(ModelPathInfo {
+            resolved_path: resolved_str,
+            exists,
+            accessible,
+            model_count,
+        })
+    })
+    .await?
+}
+
 // ── Placeholder stubs (filled in later tasks) ─────────────────────────────────
 
 #[allow(dead_code)]
@@ -185,5 +211,50 @@ mod tests {
     fn override_file_content_with_home_path() {
         let content = override_file_content("/home/user/.ollama/models");
         assert!(content.contains("OLLAMA_MODELS=/home/user/.ollama/models"));
+    }
+
+    // ── validate_model_path ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn validate_nonexistent_path() {
+        let result = validate_model_path("/nonexistent/path/xyz_alpaka_test_123".into())
+            .await
+            .unwrap();
+        assert!(!result.exists);
+        assert!(!result.accessible);
+        assert_eq!(result.model_count, 0);
+    }
+
+    #[tokio::test]
+    async fn validate_existing_empty_dir() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let result = validate_model_path(dir.path().to_str().unwrap().into())
+            .await
+            .unwrap();
+        assert!(result.exists);
+        assert!(result.accessible);
+        assert_eq!(result.model_count, 0);
+    }
+
+    #[tokio::test]
+    async fn validate_dir_with_models() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let base = dir.path().join("manifests/registry.ollama.ai/library/llama3");
+        std::fs::create_dir_all(&base).unwrap();
+        std::fs::write(base.join("latest"), b"{}").unwrap();
+
+        let result = validate_model_path(dir.path().to_str().unwrap().into())
+            .await
+            .unwrap();
+        assert!(result.exists);
+        assert!(result.accessible);
+        assert_eq!(result.model_count, 1);
+    }
+
+    #[tokio::test]
+    async fn validate_tilde_path_resolves() {
+        let result = validate_model_path("~".into()).await.unwrap();
+        assert!(result.exists);
+        assert!(!result.resolved_path.contains('~'));
     }
 }

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -33,6 +33,7 @@ pub struct ApplyModelPathResult {
 
 // ── Internal helpers ───────────────────────────────────────────────────────────
 
+#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 enum ServiceType {
     User,
@@ -84,11 +85,12 @@ pub fn count_models(base: &std::path::Path) -> u32 {
 
 /// Generate the content of a systemd service override that sets `OLLAMA_MODELS`.
 pub fn override_file_content(resolved_path: &str) -> String {
-    format!("[Service]\nEnvironment=\"OLLAMA_MODELS={}\"\n", resolved_path)
+    format!("[Service]\nEnvironment=\"OLLAMA_MODELS={resolved_path}\"\n")
 }
 
 // ── Placeholder stubs (filled in later tasks) ─────────────────────────────────
 
+#[allow(dead_code)]
 async fn detect_service_type() -> ServiceType {
     ServiceType::None
 }

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -159,6 +159,82 @@ async fn detect_service_type() -> ServiceType {
 
 // ── Service application ────────────────────────────────────────────────────────
 
+/// Remove the user-service override and restart Ollama so it falls back to its default model path.
+async fn clear_user_service() -> Result<ApplyModelPathResult, AppError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| AppError::Internal("HOME env var not set".into()))?;
+
+    let override_path = PathBuf::from(&home)
+        .join(".config/systemd/user/ollama.service.d/override.conf");
+
+    // Best-effort removal; if the file doesn't exist, that's fine.
+    let _ = std::fs::remove_file(&override_path);
+
+    let reload_ok = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !reload_ok {
+        return Err(AppError::Service(
+            "systemctl --user daemon-reload failed".into(),
+        ));
+    }
+
+    let restarted = Command::new("systemctl")
+        .args(["--user", "restart", "ollama"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    Ok(ApplyModelPathResult {
+        service_type: "user".into(),
+        applied: true,
+        restarted,
+        message: if restarted {
+            "Ollama restarted with default model path".into()
+        } else {
+            "Model path override removed. Start Ollama to apply.".into()
+        },
+    })
+}
+
+/// Remove the system-service override via pkexec and restart Ollama.
+async fn clear_system_service() -> Result<ApplyModelPathResult, AppError> {
+    let script =
+        "rm -f /etc/systemd/system/ollama.service.d/override.conf && \
+         systemctl daemon-reload && \
+         systemctl restart ollama";
+
+    let result = Command::new("pkexec")
+        .args(["sh", "-c", script])
+        .status()
+        .await;
+
+    match result {
+        Ok(s) if s.success() => Ok(ApplyModelPathResult {
+            service_type: "system".into(),
+            applied: true,
+            restarted: true,
+            message: "Ollama restarted with default model path".into(),
+        }),
+        Ok(_) => Err(AppError::Service(
+            "Elevated access was denied or failed. Override not removed.".into(),
+        )),
+        Err(e) => Err(AppError::Service(format!(
+            "pkexec not available: {}. Install polkit to remove the system service override.",
+            e
+        ))),
+    }
+}
+
 async fn apply_user_service(resolved_path: &str) -> Result<ApplyModelPathResult, AppError> {
     let home = std::env::var("HOME")
         .map_err(|_| AppError::Internal("HOME env var not set".into()))?;
@@ -253,10 +329,24 @@ pub async fn apply_model_path(
     state: State<'_, AppState>,
     path: String,
 ) -> Result<ApplyModelPathResult, AppError> {
+    db::settings::set_async(state.db.clone(), "modelPath".to_string(), path.clone()).await?;
+
+    // Empty path = clear the override so Ollama reverts to its default model path.
+    if path.trim().is_empty() {
+        return match detect_service_type().await {
+            ServiceType::User => clear_user_service().await,
+            ServiceType::System => clear_system_service().await,
+            ServiceType::None => Ok(ApplyModelPathResult {
+                service_type: "none".into(),
+                applied: true,
+                restarted: false,
+                message: "Model path cleared.".into(),
+            }),
+        };
+    }
+
     let resolved = expand_tilde(&path);
     let resolved_str = resolved.to_string_lossy().to_string();
-
-    db::settings::set_async(state.db.clone(), "modelPath".to_string(), path).await?;
 
     match detect_service_type().await {
         ServiceType::User => apply_user_service(&resolved_str).await,

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -35,7 +35,7 @@ enum ServiceType {
 }
 
 /// Expand a leading `~` to the value of `$HOME`.
-pub fn expand_tilde(path: &str) -> PathBuf {
+fn expand_tilde(path: &str) -> PathBuf {
     if path == "~" {
         if let Ok(home) = std::env::var("HOME") {
             return PathBuf::from(home);
@@ -51,7 +51,7 @@ pub fn expand_tilde(path: &str) -> PathBuf {
 /// Count Ollama model manifests under `<path>/manifests/`.
 /// Ollama stores manifests at: <path>/manifests/registry.ollama.ai/library/<name>/<tag>
 /// We walk up to 5 levels deep and count leaf files.
-pub fn count_models(base: &std::path::Path) -> u32 {
+fn count_models(base: &std::path::Path) -> u32 {
     let manifests = base.join("manifests");
     if !manifests.is_dir() {
         return 0;
@@ -77,7 +77,7 @@ pub fn count_models(base: &std::path::Path) -> u32 {
 }
 
 /// Generate the content of a systemd service override that sets `OLLAMA_MODELS`.
-pub fn override_file_content(resolved_path: &str) -> String {
+fn override_file_content(resolved_path: &str) -> String {
     format!("[Service]\nEnvironment=\"OLLAMA_MODELS={resolved_path}\"\n")
 }
 
@@ -291,10 +291,10 @@ async fn apply_system_service(resolved_path: &str) -> Result<ApplyModelPathResul
     // The model path lives in the file content, not in shell args, preventing injection.
     let script = format!(
         "mkdir -p /etc/systemd/system/ollama.service.d && \
-         cp {tmp} /etc/systemd/system/ollama.service.d/override.conf && \
+         cp '{tmp}' /etc/systemd/system/ollama.service.d/override.conf && \
          systemctl daemon-reload && \
          systemctl restart ollama",
-        tmp = tmp_path
+        tmp = tmp_path.replace('\'', "'\\''")
     );
 
     let result = Command::new("pkexec")

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -1,0 +1,187 @@
+#[allow(unused_imports)]
+use crate::db;
+#[allow(unused_imports)]
+use crate::error::AppError;
+#[allow(unused_imports)]
+use crate::state::AppState;
+use serde::Serialize;
+use std::path::PathBuf;
+#[allow(unused_imports)]
+use std::process::Stdio;
+#[allow(unused_imports)]
+use tauri::State;
+#[allow(unused_imports)]
+use tokio::process::Command;
+
+// ── Public response types ──────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ModelPathInfo {
+    pub resolved_path: String,
+    pub exists: bool,
+    pub accessible: bool,
+    pub model_count: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ApplyModelPathResult {
+    pub service_type: String,
+    pub applied: bool,
+    pub restarted: bool,
+    pub message: String,
+}
+
+// ── Internal helpers ───────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq)]
+enum ServiceType {
+    User,
+    System,
+    None,
+}
+
+/// Expand a leading `~` to the value of `$HOME`.
+pub fn expand_tilde(path: &str) -> PathBuf {
+    if path == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home);
+        }
+    } else if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = std::env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Count Ollama model manifests under `<path>/manifests/`.
+/// Ollama stores manifests at: <path>/manifests/registry.ollama.ai/library/<name>/<tag>
+/// We walk up to 5 levels deep and count leaf files.
+pub fn count_models(base: &std::path::Path) -> u32 {
+    let manifests = base.join("manifests");
+    if !manifests.is_dir() {
+        return 0;
+    }
+    fn walk(dir: &std::path::Path, depth: u8, count: &mut u32) {
+        if depth > 5 {
+            return;
+        }
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    walk(&p, depth + 1, count);
+                } else if depth >= 3 {
+                    *count += 1;
+                }
+            }
+        }
+    }
+    let mut count = 0u32;
+    walk(&manifests, 0, &mut count);
+    count
+}
+
+/// Generate the content of a systemd service override that sets `OLLAMA_MODELS`.
+pub fn override_file_content(resolved_path: &str) -> String {
+    format!("[Service]\nEnvironment=\"OLLAMA_MODELS={}\"\n", resolved_path)
+}
+
+// ── Placeholder stubs (filled in later tasks) ─────────────────────────────────
+
+async fn detect_service_type() -> ServiceType {
+    ServiceType::None
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ── expand_tilde ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn expand_tilde_bare() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(expand_tilde("~"), PathBuf::from(&home));
+    }
+
+    #[test]
+    fn expand_tilde_with_subpath() {
+        let home = std::env::var("HOME").unwrap();
+        assert_eq!(
+            expand_tilde("~/models"),
+            PathBuf::from(home).join("models")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_absolute_path_unchanged() {
+        assert_eq!(
+            expand_tilde("/usr/share/ollama/models"),
+            PathBuf::from("/usr/share/ollama/models")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_relative_path_unchanged() {
+        assert_eq!(expand_tilde("models"), PathBuf::from("models"));
+    }
+
+    // ── count_models ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn count_models_empty_dir() {
+        let dir = TempDir::new().unwrap();
+        assert_eq!(count_models(dir.path()), 0);
+    }
+
+    #[test]
+    fn count_models_no_manifests_subdir() {
+        let dir = TempDir::new().unwrap();
+        fs::create_dir(dir.path().join("blobs")).unwrap();
+        assert_eq!(count_models(dir.path()), 0);
+    }
+
+    #[test]
+    fn count_models_one_model() {
+        let dir = TempDir::new().unwrap();
+        let manifest_path = dir
+            .path()
+            .join("manifests/registry.ollama.ai/library/llama3");
+        fs::create_dir_all(&manifest_path).unwrap();
+        fs::write(manifest_path.join("latest"), b"{}").unwrap();
+        assert_eq!(count_models(dir.path()), 1);
+    }
+
+    #[test]
+    fn count_models_two_models() {
+        let dir = TempDir::new().unwrap();
+        let base = dir.path().join("manifests/registry.ollama.ai/library");
+        fs::create_dir_all(base.join("llama3")).unwrap();
+        fs::write(base.join("llama3/latest"), b"{}").unwrap();
+        fs::create_dir_all(base.join("mistral")).unwrap();
+        fs::write(base.join("mistral/7b"), b"{}").unwrap();
+        assert_eq!(count_models(dir.path()), 2);
+    }
+
+    // ── override_file_content ─────────────────────────────────────────────────
+
+    #[test]
+    fn override_file_content_format() {
+        let content = override_file_content("/mnt/data/models");
+        assert_eq!(
+            content,
+            "[Service]\nEnvironment=\"OLLAMA_MODELS=/mnt/data/models\"\n"
+        );
+    }
+
+    #[test]
+    fn override_file_content_with_home_path() {
+        let content = override_file_content("/home/user/.ollama/models");
+        assert!(content.contains("OLLAMA_MODELS=/home/user/.ollama/models"));
+    }
+}

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -124,7 +124,6 @@ async fn run_systemctl(args: &[&str]) -> bool {
         .unwrap_or(false)
 }
 
-#[allow(dead_code)]
 async fn detect_service_type() -> ServiceType {
     // Prefer user service — no elevated privileges needed
     let user_checks: &[&[&str]] = &[
@@ -196,6 +195,68 @@ async fn apply_user_service(resolved_path: &str) -> Result<ApplyModelPathResult,
             "Model path configured. Start Ollama to apply.".into()
         },
     })
+}
+
+async fn apply_system_service(resolved_path: &str) -> Result<ApplyModelPathResult, AppError> {
+    let tmp_path = "/tmp/alpaka_ollama_override.conf";
+    std::fs::write(tmp_path, override_file_content(resolved_path))?;
+
+    // Single pkexec call = single polkit password prompt.
+    // The model path lives in the file content, not in shell args, preventing injection.
+    let script = format!(
+        "mkdir -p /etc/systemd/system/ollama.service.d && \
+         cp {tmp} /etc/systemd/system/ollama.service.d/override.conf && \
+         systemctl daemon-reload && \
+         systemctl restart ollama",
+        tmp = tmp_path
+    );
+
+    let result = Command::new("pkexec")
+        .args(["sh", "-c", &script])
+        .status()
+        .await;
+
+    let _ = std::fs::remove_file(tmp_path);
+
+    match result {
+        Ok(s) if s.success() => Ok(ApplyModelPathResult {
+            service_type: "system".into(),
+            applied: true,
+            restarted: true,
+            message: "Ollama restarted with new model path".into(),
+        }),
+        Ok(_) => Err(AppError::Service(
+            "Elevated access was denied or failed. Model path not applied.".into(),
+        )),
+        Err(e) => Err(AppError::Service(format!(
+            "pkexec not available: {}. Install polkit to configure the system service.",
+            e
+        ))),
+    }
+}
+
+#[tauri::command]
+pub async fn apply_model_path(
+    state: State<'_, AppState>,
+    path: String,
+) -> Result<ApplyModelPathResult, AppError> {
+    let resolved = expand_tilde(&path);
+    let resolved_str = resolved.to_string_lossy().to_string();
+
+    db::settings::set_async(state.db.clone(), "modelPath".to_string(), path).await?;
+
+    match detect_service_type().await {
+        ServiceType::User => apply_user_service(&resolved_str).await,
+        ServiceType::System => apply_system_service(&resolved_str).await,
+        ServiceType::None => Ok(ApplyModelPathResult {
+            service_type: "none".into(),
+            applied: false,
+            restarted: false,
+            message: format!(
+                "Path saved. Set OLLAMA_MODELS={resolved_str} in your environment before starting Ollama."
+            ),
+        }),
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -6,11 +6,9 @@ use crate::error::AppError;
 use crate::state::AppState;
 use serde::Serialize;
 use std::path::PathBuf;
-#[allow(unused_imports)]
 use std::process::Stdio;
 #[allow(unused_imports)]
 use tauri::State;
-#[allow(unused_imports)]
 use tokio::process::Command;
 
 // ── Public response types ──────────────────────────────────────────────────────
@@ -33,7 +31,6 @@ pub struct ApplyModelPathResult {
 
 // ── Internal helpers ───────────────────────────────────────────────────────────
 
-#[allow(dead_code)]
 #[derive(Debug, PartialEq)]
 enum ServiceType {
     User,
@@ -114,10 +111,43 @@ pub async fn validate_model_path(path: String) -> Result<ModelPathInfo, AppError
     .await?
 }
 
-// ── Placeholder stubs (filled in later tasks) ─────────────────────────────────
+// ── Service detection ─────────────────────────────────────────────────────────
+
+async fn run_systemctl(args: &[&str]) -> bool {
+    Command::new("systemctl")
+        .args(args)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
 
 #[allow(dead_code)]
 async fn detect_service_type() -> ServiceType {
+    // Prefer user service — no elevated privileges needed
+    let user_checks: &[&[&str]] = &[
+        &["--user", "is-enabled", "ollama"],
+        &["--user", "is-active", "ollama"],
+    ];
+    for args in user_checks {
+        if run_systemctl(args).await {
+            return ServiceType::User;
+        }
+    }
+
+    // Fall back to system service
+    let system_checks: &[&[&str]] = &[
+        &["is-enabled", "ollama"],
+        &["is-active", "ollama"],
+    ];
+    for args in system_checks {
+        if run_systemctl(args).await {
+            return ServiceType::System;
+        }
+    }
+
     ServiceType::None
 }
 

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -88,15 +88,26 @@ pub async fn validate_model_path(path: String) -> Result<ModelPathInfo, AppError
     tokio::task::spawn_blocking(move || {
         let resolved = expand_tilde(&path);
         let resolved_str = resolved.to_string_lossy().to_string();
-        let exists = resolved.is_dir();
-        let (accessible, model_count) = if exists {
-            match std::fs::read_dir(&resolved) {
-                Ok(_) => (true, count_models(&resolved)),
-                Err(_) => (false, 0),
+
+        // Use metadata() instead of is_dir() so we can distinguish EACCES from ENOENT.
+        // is_dir() returns false for both, which causes system paths (parent dir mode 700)
+        // to incorrectly report as non-existent.
+        let (exists, accessible, model_count) = match std::fs::metadata(&resolved) {
+            Ok(m) if m.is_dir() => {
+                match std::fs::read_dir(&resolved) {
+                    Ok(_) => (true, true, count_models(&resolved)),
+                    Err(_) => (true, false, 0),
+                }
             }
-        } else {
-            (false, 0)
+            Ok(_) => (false, false, 0), // exists but is a file, not a dir
+            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
+                // Parent directory not traversable (e.g. /usr/share/ollama/.ollama/ is mode 700).
+                // The path likely exists — treat as inaccessible, not missing.
+                (true, false, 0)
+            }
+            Err(_) => (false, false, 0),
         };
+
         Ok(ModelPathInfo {
             resolved_path: resolved_str,
             exists,

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -1,13 +1,9 @@
-#[allow(unused_imports)]
 use crate::db;
-#[allow(unused_imports)]
 use crate::error::AppError;
-#[allow(unused_imports)]
 use crate::state::AppState;
 use serde::Serialize;
 use std::path::PathBuf;
 use std::process::Stdio;
-#[allow(unused_imports)]
 use tauri::State;
 use tokio::process::Command;
 
@@ -198,8 +194,11 @@ async fn apply_user_service(resolved_path: &str) -> Result<ApplyModelPathResult,
 }
 
 async fn apply_system_service(resolved_path: &str) -> Result<ApplyModelPathResult, AppError> {
-    let tmp_path = "/tmp/alpaka_ollama_override.conf";
-    std::fs::write(tmp_path, override_file_content(resolved_path))?;
+    // Use $XDG_RUNTIME_DIR (mode 0700, per-user) to avoid a world-writable /tmp symlink attack.
+    let runtime_dir = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
+    let tmp_path = format!("{}/alpaka_ollama_override.conf", runtime_dir);
+    std::fs::write(&tmp_path, override_file_content(resolved_path))?;
 
     // Single pkexec call = single polkit password prompt.
     // The model path lives in the file content, not in shell args, preventing injection.
@@ -216,15 +215,18 @@ async fn apply_system_service(resolved_path: &str) -> Result<ApplyModelPathResul
         .status()
         .await;
 
-    let _ = std::fs::remove_file(tmp_path);
+    let _ = std::fs::remove_file(&tmp_path);
 
     match result {
-        Ok(s) if s.success() => Ok(ApplyModelPathResult {
-            service_type: "system".into(),
-            applied: true,
-            restarted: true,
-            message: "Ollama restarted with new model path".into(),
-        }),
+        Ok(s) if s.success() => {
+            // pkexec exited 0 → all commands in the &&-chain succeeded, including restart
+            Ok(ApplyModelPathResult {
+                service_type: "system".into(),
+                applied: true,
+                restarted: true,
+                message: "Ollama restarted with new model path".into(),
+            })
+        }
         Ok(_) => Err(AppError::Service(
             "Elevated access was denied or failed. Model path not applied.".into(),
         )),

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -93,12 +93,10 @@ pub async fn validate_model_path(path: String) -> Result<ModelPathInfo, AppError
         // is_dir() returns false for both, which causes system paths (parent dir mode 700)
         // to incorrectly report as non-existent.
         let (exists, accessible, model_count) = match std::fs::metadata(&resolved) {
-            Ok(m) if m.is_dir() => {
-                match std::fs::read_dir(&resolved) {
-                    Ok(_) => (true, true, count_models(&resolved)),
-                    Err(_) => (true, false, 0),
-                }
-            }
+            Ok(m) if m.is_dir() => match std::fs::read_dir(&resolved) {
+                Ok(_) => (true, true, count_models(&resolved)),
+                Err(_) => (true, false, 0),
+            },
             Ok(_) => (false, false, 0), // exists but is a file, not a dir
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                 // Parent directory not traversable (e.g. /usr/share/ollama/.ollama/ is mode 700).
@@ -144,10 +142,7 @@ async fn detect_service_type() -> ServiceType {
     }
 
     // Fall back to system service
-    let system_checks: &[&[&str]] = &[
-        &["is-enabled", "ollama"],
-        &["is-active", "ollama"],
-    ];
+    let system_checks: &[&[&str]] = &[&["is-enabled", "ollama"], &["is-active", "ollama"]];
     for args in system_checks {
         if run_systemctl(args).await {
             return ServiceType::System;
@@ -161,11 +156,11 @@ async fn detect_service_type() -> ServiceType {
 
 /// Remove the user-service override and restart Ollama so it falls back to its default model path.
 async fn clear_user_service() -> Result<ApplyModelPathResult, AppError> {
-    let home = std::env::var("HOME")
-        .map_err(|_| AppError::Internal("HOME env var not set".into()))?;
+    let home =
+        std::env::var("HOME").map_err(|_| AppError::Internal("HOME env var not set".into()))?;
 
-    let override_path = PathBuf::from(&home)
-        .join(".config/systemd/user/ollama.service.d/override.conf");
+    let override_path =
+        PathBuf::from(&home).join(".config/systemd/user/ollama.service.d/override.conf");
 
     // Best-effort removal; if the file doesn't exist, that's fine.
     let _ = std::fs::remove_file(&override_path);
@@ -208,8 +203,7 @@ async fn clear_user_service() -> Result<ApplyModelPathResult, AppError> {
 
 /// Remove the system-service override via pkexec and restart Ollama.
 async fn clear_system_service() -> Result<ApplyModelPathResult, AppError> {
-    let script =
-        "rm -f /etc/systemd/system/ollama.service.d/override.conf && \
+    let script = "rm -f /etc/systemd/system/ollama.service.d/override.conf && \
          systemctl daemon-reload && \
          systemctl restart ollama";
 
@@ -236,13 +230,15 @@ async fn clear_system_service() -> Result<ApplyModelPathResult, AppError> {
 }
 
 async fn apply_user_service(resolved_path: &str) -> Result<ApplyModelPathResult, AppError> {
-    let home = std::env::var("HOME")
-        .map_err(|_| AppError::Internal("HOME env var not set".into()))?;
+    let home =
+        std::env::var("HOME").map_err(|_| AppError::Internal("HOME env var not set".into()))?;
 
-    let override_dir = PathBuf::from(&home)
-        .join(".config/systemd/user/ollama.service.d");
+    let override_dir = PathBuf::from(&home).join(".config/systemd/user/ollama.service.d");
     std::fs::create_dir_all(&override_dir)?;
-    std::fs::write(override_dir.join("override.conf"), override_file_content(resolved_path))?;
+    std::fs::write(
+        override_dir.join("override.conf"),
+        override_file_content(resolved_path),
+    )?;
 
     let reload_ok = Command::new("systemctl")
         .args(["--user", "daemon-reload"])
@@ -381,10 +377,7 @@ mod tests {
     #[test]
     fn expand_tilde_with_subpath() {
         let home = std::env::var("HOME").unwrap();
-        assert_eq!(
-            expand_tilde("~/models"),
-            PathBuf::from(home).join("models")
-        );
+        assert_eq!(expand_tilde("~/models"), PathBuf::from(home).join("models"));
     }
 
     #[test]
@@ -480,7 +473,9 @@ mod tests {
     #[tokio::test]
     async fn validate_dir_with_models() {
         let dir = tempfile::TempDir::new().unwrap();
-        let base = dir.path().join("manifests/registry.ollama.ai/library/llama3");
+        let base = dir
+            .path()
+            .join("manifests/registry.ollama.ai/library/llama3");
         std::fs::create_dir_all(&base).unwrap();
         std::fs::write(base.join("latest"), b"{}").unwrap();
 

--- a/src-tauri/src/commands/model_path.rs
+++ b/src-tauri/src/commands/model_path.rs
@@ -151,6 +151,53 @@ async fn detect_service_type() -> ServiceType {
     ServiceType::None
 }
 
+// ── Service application ────────────────────────────────────────────────────────
+
+async fn apply_user_service(resolved_path: &str) -> Result<ApplyModelPathResult, AppError> {
+    let home = std::env::var("HOME")
+        .map_err(|_| AppError::Internal("HOME env var not set".into()))?;
+
+    let override_dir = PathBuf::from(&home)
+        .join(".config/systemd/user/ollama.service.d");
+    std::fs::create_dir_all(&override_dir)?;
+    std::fs::write(override_dir.join("override.conf"), override_file_content(resolved_path))?;
+
+    let reload_ok = Command::new("systemctl")
+        .args(["--user", "daemon-reload"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    if !reload_ok {
+        return Err(AppError::Service(
+            "systemctl --user daemon-reload failed".into(),
+        ));
+    }
+
+    let restarted = Command::new("systemctl")
+        .args(["--user", "restart", "ollama"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false);
+
+    Ok(ApplyModelPathResult {
+        service_type: "user".into(),
+        applied: true,
+        restarted,
+        message: if restarted {
+            "Ollama restarted with new model path".into()
+        } else {
+            "Model path configured. Start Ollama to apply.".into()
+        },
+    })
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -286,5 +333,22 @@ mod tests {
         let result = validate_model_path("~".into()).await.unwrap();
         assert!(result.exists);
         assert!(!result.resolved_path.contains('~'));
+    }
+
+    // ── apply_user_service ────────────────────────────────────────────────────
+
+    #[test]
+    fn user_override_file_content_is_correct() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let override_dir = dir.path().join("ollama.service.d");
+        std::fs::create_dir_all(&override_dir).unwrap();
+        let override_path = override_dir.join("override.conf");
+        std::fs::write(&override_path, override_file_content("/mnt/models")).unwrap();
+
+        let written = std::fs::read_to_string(&override_path).unwrap();
+        assert_eq!(
+            written,
+            "[Service]\nEnvironment=\"OLLAMA_MODELS=/mnt/models\"\n"
+        );
     }
 }

--- a/src-tauri/src/db/hosts.rs
+++ b/src-tauri/src/db/hosts.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::error::AppError;
+use crate::ollama::client::is_cloud_host;
 
 // ── Domain type ────────────────────────────────────────────────────────────────
 
@@ -12,6 +13,7 @@ pub struct Host {
     pub id: String,
     pub name: String,
     pub url: String,
+    pub kind: String,
     pub is_default: bool,
     pub is_active: bool,
     pub last_ping_status: PingStatus,
@@ -64,11 +66,19 @@ fn row_to_host(row: &rusqlite::Row<'_>) -> rusqlite::Result<Host> {
     let last_ping_status = status_str
         .parse::<PingStatus>()
         .unwrap_or(PingStatus::Unknown);
+    let url: String = row.get(2)?;
+    let kind = if is_cloud_host(&url) {
+        "cloud"
+    } else {
+        "local"
+    }
+    .to_string();
 
     Ok(Host {
         id: row.get(0)?,
         name: row.get(1)?,
-        url: row.get(2)?,
+        url,
+        kind,
         is_default: row.get::<_, i64>(3)? != 0,
         is_active: row.get::<_, i64>(5)? != 0,
         last_ping_status,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,8 @@ pub fn run() {
             commands::models::delete_model,
             commands::models::pull_model,
             commands::models::get_model_capabilities,
+            commands::model_path::validate_model_path,
+            commands::model_path::apply_model_path,
             commands::auth::login,
             commands::auth::logout,
             commands::auth::get_auth_status,

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -137,4 +137,34 @@ describe("useModelStore", () => {
 
     expect(mockListen).toHaveBeenCalledTimes(2); // once for each event, not 4
   });
+
+  it("fetchModels sets error from tagged-enum object { Http: 'connection refused' }", async () => {
+    const store = useModelStore();
+    mockInvoke.mockRejectedValue({ Http: "connection refused" });
+
+    await store.fetchModels();
+
+    expect(store.error).toBe("Http: connection refused");
+    expect(store.isLoading).toBe(false);
+  });
+
+  it("fetchModels sets error from plain string rejection", async () => {
+    const store = useModelStore();
+    mockInvoke.mockRejectedValue("network timeout");
+
+    await store.fetchModels();
+
+    expect(store.error).toBe("network timeout");
+    expect(store.isLoading).toBe(false);
+  });
+
+  it("fetchModels sets error to '{}' when rejected with an empty object", async () => {
+    const store = useModelStore();
+    mockInvoke.mockRejectedValue({});
+
+    await store.fetchModels();
+
+    expect(store.error).toBe("{}");
+    expect(store.isLoading).toBe(false);
+  });
 });

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -6,7 +6,6 @@ import type {
   PullProgressPayload,
   LibraryModel,
   ModelCapabilities,
-  PullHistoryEntry,
   LibraryTag,
   LaunchApp,
 } from "../types/models";
@@ -23,7 +22,6 @@ export const useModelStore = defineStore("models", {
     capabilities: {} as Record<string, ModelCapabilities>,
     // Library search state
     libraryResults: [] as LibraryModel[],
-    pullHistory: [] as PullHistoryEntry[],
     searchQuery: "",
     isSearching: false,
     _searchTimer: null as ReturnType<typeof setTimeout> | null,
@@ -195,28 +193,16 @@ export const useModelStore = defineStore("models", {
       if (this.listenersInitialized) return;
       this.listenersInitialized = true;
 
-      this.fetchPullHistory();
-
       await listen<PullProgressPayload>("model:pull-progress", (event) => {
         const payload = event.payload;
         this.pulling[payload.model] = payload;
-        // Optionally refresh history during pull if status changes significantly
       });
       await listen<{ model: string }>("model:pull-done", (event) => {
         const payload = event.payload;
         delete this.pulling[payload.model];
-        this.fetchModels(); // Refresh list automatically
-        this.fetchPullHistory(); // Also refresh history
-        this.fetchCapabilities(payload.model); // Re-fetch capabilities now that it's ready
+        this.fetchModels();
+        this.fetchCapabilities(payload.model);
       });
-    },
-
-    async fetchPullHistory() {
-      try {
-        this.pullHistory = await invoke<PullHistoryEntry[]>("get_pull_history");
-      } catch (err) {
-        console.error("Failed to fetch pull history:", err);
-      }
     },
 
     formatBytes(bytes: number) {

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -55,15 +55,18 @@ export const useModelStore = defineStore("models", {
             console.error("Failed to fetch capabilities for some models:", err),
         );
       } catch (e: unknown) {
-        // Tauri AppError serializes as a tagged object, e.g. {"Http":"connection refused"}
-        if (e && typeof e === "object" && !Array.isArray(e)) {
+        // Tauri AppError serializes as a tagged object e.g. {"Http":"connection refused"}.
+        // Check instanceof Error first since Error properties are non-enumerable.
+        if (e instanceof Error) {
+          this.error = e.message;
+        } else if (e && typeof e === "object" && !Array.isArray(e)) {
           const entries = Object.entries(e as Record<string, unknown>);
           this.error =
             entries.length > 0
               ? entries.map(([k, v]) => `${k}: ${v}`).join("; ")
               : JSON.stringify(e);
         } else {
-          this.error = e instanceof Error ? e.message : String(e);
+          this.error = String(e);
         }
         console.error("[models] fetchModels failed:", e);
       } finally {

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -55,7 +55,17 @@ export const useModelStore = defineStore("models", {
             console.error("Failed to fetch capabilities for some models:", err),
         );
       } catch (e: unknown) {
-        this.error = e instanceof Error ? e.message : String(e);
+        // Tauri AppError serializes as a tagged object, e.g. {"Http":"connection refused"}
+        if (e && typeof e === "object" && !Array.isArray(e)) {
+          const entries = Object.entries(e as Record<string, unknown>);
+          this.error =
+            entries.length > 0
+              ? entries.map(([k, v]) => `${k}: ${v}`).join("; ")
+              : JSON.stringify(e);
+        } else {
+          this.error = e instanceof Error ? e.message : String(e);
+        }
+        console.error("[models] fetchModels failed:", e);
       } finally {
         this.isLoading = false;
       }

--- a/src/types/hosts.ts
+++ b/src/types/hosts.ts
@@ -2,6 +2,7 @@ export interface Host {
   id: string;
   name: string;
   url: string;
+  kind: "local" | "cloud";
   is_default: boolean;
   is_active: boolean;
   last_ping_status: "online" | "offline" | "unknown";

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -124,7 +124,9 @@
                   v-else-if="modelStore.error"
                   class="flex flex-col items-center gap-3 text-[13px] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--danger)]/40 rounded-xl"
                 >
-                  <span class="text-[var(--danger)]">Failed to load models: {{ modelStoreErrorMessage }}</span>
+                  <span class="text-[var(--danger)]"
+                    >Failed to load models: {{ modelStoreErrorMessage }}</span
+                  >
                   <button
                     @click="modelStore.fetchModels()"
                     class="px-4 py-1.5 bg-[var(--bg-hover)] border border-[var(--border-strong)] rounded-lg text-[12px] text-[var(--text)] cursor-pointer hover:bg-[var(--bg-active)] transition-colors"
@@ -136,7 +138,10 @@
                   v-else-if="modelStore.models.length === 0"
                   class="flex flex-col items-center gap-3 text-[13px] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--border-subtle)] rounded-xl"
                 >
-                  <span class="text-[var(--text-dim)]">No models installed locally. Go to Library to pull one!</span>
+                  <span class="text-[var(--text-dim)]"
+                    >No models installed locally. Go to Library to pull
+                    one!</span
+                  >
                   <button
                     @click="modelStore.fetchModels()"
                     class="px-4 py-1.5 bg-[var(--bg-hover)] border border-[var(--border-strong)] rounded-lg text-[12px] text-[var(--text)] cursor-pointer hover:bg-[var(--bg-active)] transition-colors"
@@ -424,19 +429,7 @@ import { storeToRefs } from "pinia";
 const modelStore = useModelStore();
 const { selectedModel } = storeToRefs(modelStore);
 
-const modelStoreErrorMessage = computed(() => {
-  const e = modelStore.error;
-  if (!e) return "";
-  if (typeof e === "string") return e;
-  if (e instanceof Error) return (e as Error).message;
-  if (typeof e === "object" && !Array.isArray(e)) {
-    const entries = Object.entries(e as Record<string, unknown>);
-    return entries.length > 0
-      ? entries.map(([k, v]) => `${k}: ${v}`).join("; ")
-      : JSON.stringify(e);
-  }
-  return String(e);
-});
+const modelStoreErrorMessage = computed(() => modelStore.error ?? "");
 const orchestration = useAppOrchestration();
 const router = useRouter();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -124,7 +124,7 @@
                   v-else-if="modelStore.error"
                   class="flex flex-col items-center gap-3 text-[13px] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--danger)]/40 rounded-xl"
                 >
-                  <span class="text-[var(--danger)]">Failed to load models: {{ modelStore.error }}</span>
+                  <span class="text-[var(--danger)]">Failed to load models: {{ modelStoreErrorMessage }}</span>
                   <button
                     @click="modelStore.fetchModels()"
                     class="px-4 py-1.5 bg-[var(--bg-hover)] border border-[var(--border-strong)] rounded-lg text-[12px] text-[var(--text)] cursor-pointer hover:bg-[var(--bg-active)] transition-colors"
@@ -423,6 +423,20 @@ import { storeToRefs } from "pinia";
 
 const modelStore = useModelStore();
 const { selectedModel } = storeToRefs(modelStore);
+
+const modelStoreErrorMessage = computed(() => {
+  const e = modelStore.error;
+  if (!e) return "";
+  if (typeof e === "string") return e;
+  if (e instanceof Error) return (e as Error).message;
+  if (typeof e === "object" && !Array.isArray(e)) {
+    const entries = Object.entries(e as Record<string, unknown>);
+    return entries.length > 0
+      ? entries.map(([k, v]) => `${k}: ${v}`).join("; ")
+      : JSON.stringify(e);
+  }
+  return String(e);
+});
 const orchestration = useAppOrchestration();
 const router = useRouter();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -121,10 +121,28 @@
                   <p>Loading installed models...</p>
                 </div>
                 <div
-                  v-else-if="modelStore.models.length === 0"
-                  class="text-[13px] text-[var(--text-dim)] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--border-subtle)] rounded-xl"
+                  v-else-if="modelStore.error"
+                  class="flex flex-col items-center gap-3 text-[13px] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--danger)]/40 rounded-xl"
                 >
-                  No models installed locally. Go to Library to pull one!
+                  <span class="text-[var(--danger)]">Failed to load models: {{ modelStore.error }}</span>
+                  <button
+                    @click="modelStore.fetchModels()"
+                    class="px-4 py-1.5 bg-[var(--bg-hover)] border border-[var(--border-strong)] rounded-lg text-[12px] text-[var(--text)] cursor-pointer hover:bg-[var(--bg-active)] transition-colors"
+                  >
+                    Retry
+                  </button>
+                </div>
+                <div
+                  v-else-if="modelStore.models.length === 0"
+                  class="flex flex-col items-center gap-3 text-[13px] py-12 text-center bg-[var(--bg-input)] border border-dashed border-[var(--border-subtle)] rounded-xl"
+                >
+                  <span class="text-[var(--text-dim)]">No models installed locally. Go to Library to pull one!</span>
+                  <button
+                    @click="modelStore.fetchModels()"
+                    class="px-4 py-1.5 bg-[var(--bg-hover)] border border-[var(--border-strong)] rounded-lg text-[12px] text-[var(--text)] cursor-pointer hover:bg-[var(--bg-active)] transition-colors"
+                  >
+                    Refresh
+                  </button>
                 </div>
                 <div v-else class="flex flex-col gap-1.5">
                   <p

--- a/src/views/SettingsPage.modelpath.spec.ts
+++ b/src/views/SettingsPage.modelpath.spec.ts
@@ -48,8 +48,13 @@ vi.mock("../components/settings/AccountSettings.vue", () => ({
 function makeHost(
   overrides: Partial<Host> & { id: string; url: string },
 ): Host {
+  const url = overrides.url;
+  const kind: "local" | "cloud" = url.includes("api.ollama.com")
+    ? "cloud"
+    : "local";
   return {
     name: "local",
+    kind,
     is_default: true,
     is_active: true,
     last_ping_status: "online",
@@ -343,7 +348,6 @@ describe("SettingsPage — applyModelPath", () => {
         });
       }
       if (cmd === "list_hosts") {
-        // Return cloud host as active so ensureLocalHost triggers switch
         return Promise.resolve([
           { ...cloudHost, is_active: true },
           { ...localHost, is_active: false },

--- a/src/views/SettingsPage.modelpath.spec.ts
+++ b/src/views/SettingsPage.modelpath.spec.ts
@@ -49,9 +49,8 @@ function makeHost(
   overrides: Partial<Host> & { id: string; url: string },
 ): Host {
   const url = overrides.url;
-  const kind: "local" | "cloud" = url.includes("api.ollama.com")
-    ? "cloud"
-    : "local";
+  const kind: "local" | "cloud" =
+    new URL(url).hostname === "api.ollama.com" ? "cloud" : "local";
   return {
     name: "local",
     kind,

--- a/src/views/SettingsPage.modelpath.spec.ts
+++ b/src/views/SettingsPage.modelpath.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * SettingsPage — Model storage path feature (MO-08)
+ *
+ * Tests the watch-based validation flow and the applyModelPath / browseModelPath
+ * functions that live inside <script setup>.  All Tauri IPC is intercepted via
+ * the module-level mockInvoke, and fake timers advance the debounce delays.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import SettingsPage from "./SettingsPage.vue";
+import { useSettingsStore } from "../stores/settings";
+import { useHostStore } from "../stores/hosts";
+import type { Host } from "../types/hosts";
+
+// ── Module-level mocks ────────────────────────────────────────────────────────
+
+const mockInvoke = vi.fn();
+const mockOpen = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) =>
+    mockInvoke(cmd, args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: (...args: unknown[]) => mockOpen(...args),
+}));
+
+// Stub heavy child components that have their own Tauri / store dependencies
+vi.mock("../components/settings/HostSettings.vue", () => ({
+  default: { template: "<div />" },
+}));
+vi.mock("../components/shared/AppTabs.vue", () => ({
+  default: { template: "<div><slot /></div>" },
+}));
+vi.mock("../components/settings/AccountSettings.vue", () => ({
+  default: { template: "<div />" },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeHost(
+  overrides: Partial<Host> & { id: string; url: string },
+): Host {
+  return {
+    name: "local",
+    is_default: true,
+    is_active: true,
+    last_ping_status: "online",
+    last_ping_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+/** Mount SettingsPage against the active Pinia (set in beforeEach). */
+function mountPage() {
+  return mount(SettingsPage, {
+    global: {
+      stubs: {
+        SettingsRow: { template: "<div><slot name='control' /></div>" },
+        ToggleSwitch: true,
+        SettingsSlider: true,
+        ConfirmationModal: true,
+        Transition: { template: "<div><slot /></div>" },
+      },
+    },
+  });
+}
+
+// Internal-ref shape exposed through wrapper.vm proxy
+interface SettingsPageVM {
+  applyModelPath: (path: string) => Promise<void>;
+  browseModelPath: () => Promise<void>;
+  pathValidation: { status: string; message: string; modelCount: number };
+  pathApply: { status: string; message: string };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("SettingsPage — model path validation (watch)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockOpen.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("empty modelPath → pathValidation.status is 'idle' (no invoke)", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = ""; // ensure empty before mount
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("idle");
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "validate_model_path",
+      expect.anything(),
+    );
+  });
+
+  it("non-existent path → status 'error', message contains 'does not exist'", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = ""; // start empty so mount watch fires idle
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "validate_model_path") {
+        return Promise.resolve({
+          exists: false,
+          accessible: false,
+          model_count: 0,
+          resolved_path: "/bad/path",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    // Now trigger the watch by setting a path
+    settingsStore.modelPath = "/bad/path";
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("checking");
+
+    // Advance past the 500 ms debounce
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    expect(vm.pathValidation.status).toBe("error");
+    expect(vm.pathValidation.message).toContain("does not exist");
+  });
+
+  it("inaccessible path → status 'warning', message contains 'elevated access'", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = "";
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "validate_model_path") {
+        return Promise.resolve({
+          exists: true,
+          accessible: false,
+          model_count: 0,
+          resolved_path: "/sys/path",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    settingsStore.modelPath = "/sys/path";
+    await wrapper.vm.$nextTick();
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("warning");
+    expect(vm.pathValidation.message).toContain("elevated access");
+  });
+
+  it("accessible path with 0 models → status 'warning', message contains 'No Ollama models'", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = "";
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "validate_model_path") {
+        return Promise.resolve({
+          exists: true,
+          accessible: true,
+          model_count: 0,
+          resolved_path: "/empty/path",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    settingsStore.modelPath = "/empty/path";
+    await wrapper.vm.$nextTick();
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("warning");
+    expect(vm.pathValidation.message).toContain("No Ollama models");
+  });
+
+  it("accessible path with 3 models → status 'ok', message = 'Found 3 model(s)'", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = "";
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "validate_model_path") {
+        return Promise.resolve({
+          exists: true,
+          accessible: true,
+          model_count: 3,
+          resolved_path: "/good/path",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    settingsStore.modelPath = "/good/path";
+    await wrapper.vm.$nextTick();
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("ok");
+    expect(vm.pathValidation.message).toBe("Found 3 model(s)");
+  });
+
+  it("validate_model_path throws → status 'error', message = 'Validation failed'", async () => {
+    const settingsStore = useSettingsStore();
+    settingsStore.modelPath = "";
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "validate_model_path") {
+        return Promise.reject(new Error("IPC error"));
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    settingsStore.modelPath = "/some/path";
+    await wrapper.vm.$nextTick();
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    expect(vm.pathValidation.status).toBe("error");
+    expect(vm.pathValidation.message).toBe("Validation failed");
+  });
+});
+
+describe("SettingsPage — applyModelPath", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockOpen.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("user/system service success → pathApply.status = 'success'", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.resolve({
+          service_type: "user",
+          applied: true,
+          restarted: false,
+          message: "Done",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.applyModelPath("/some/path");
+    await wrapper.vm.$nextTick();
+
+    expect(vm.pathApply.status).toBe("success");
+    expect(vm.pathApply.message).toBe("Done");
+  });
+
+  it("service_type 'none' → pathApply.status = 'manual'", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.resolve({
+          service_type: "none",
+          applied: false,
+          restarted: false,
+          message: "Restart manually",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.applyModelPath("/some/path");
+    await wrapper.vm.$nextTick();
+
+    expect(vm.pathApply.status).toBe("manual");
+    expect(vm.pathApply.message).toBe("Restart manually");
+  });
+
+  it("restarted + active host is cloud → setActiveHost called with local host id", async () => {
+    const cloudHost = makeHost({
+      id: "cloud-1",
+      url: "https://api.ollama.com",
+      is_active: true,
+    });
+    const localHost = makeHost({
+      id: "local-1",
+      url: "http://localhost:11434",
+      is_active: false,
+    });
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.resolve({
+          service_type: "user",
+          applied: true,
+          restarted: true,
+          message: "Restarted",
+        });
+      }
+      if (cmd === "list_hosts") {
+        // Return cloud host as active so ensureLocalHost triggers switch
+        return Promise.resolve([
+          { ...cloudHost, is_active: true },
+          { ...localHost, is_active: false },
+        ]);
+      }
+      if (cmd === "set_active_host") {
+        return Promise.resolve(undefined);
+      }
+      if (cmd === "list_models") {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve([]);
+    });
+
+    // Pre-populate the host store so activeHost resolves to the cloud host before fetchHosts runs
+    const hostStore = useHostStore();
+    hostStore.hosts = [cloudHost, localHost];
+    hostStore.activeHostId = "cloud-1";
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.applyModelPath("/some/path");
+    await wrapper.vm.$nextTick();
+
+    // Advance the 2000ms restart timer (contains ensureLocalHost + fetchModels)
+    await vi.runAllTimersAsync();
+    await wrapper.vm.$nextTick();
+
+    expect(mockInvoke).toHaveBeenCalledWith("set_active_host", {
+      id: "local-1",
+    });
+  });
+
+  it("apply_model_path throws Error → pathApply.status = 'error', message from Error.message", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.reject(new Error("Permission denied"));
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.applyModelPath("/some/path");
+    await wrapper.vm.$nextTick();
+
+    expect(vm.pathApply.status).toBe("error");
+    expect(vm.pathApply.message).toBe("Permission denied");
+  });
+
+  it("apply_model_path throws plain string → pathApply.status = 'error', message is that string", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.reject("disk full");
+      }
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.applyModelPath("/some/path");
+    await wrapper.vm.$nextTick();
+
+    expect(vm.pathApply.status).toBe("error");
+    expect(vm.pathApply.message).toBe("disk full");
+  });
+});
+
+describe("SettingsPage — browseModelPath", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockOpen.mockReset();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("dialog returns a path → settingsStore.modelPath updated and applyModelPath called", async () => {
+    mockOpen.mockResolvedValue("/chosen/path");
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "apply_model_path") {
+        return Promise.resolve({
+          service_type: "user",
+          applied: true,
+          restarted: false,
+          message: "OK",
+        });
+      }
+      return Promise.resolve([]);
+    });
+
+    const settingsStore = useSettingsStore();
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.browseModelPath();
+    await wrapper.vm.$nextTick();
+
+    expect(settingsStore.modelPath).toBe("/chosen/path");
+    expect(mockInvoke).toHaveBeenCalledWith("apply_model_path", {
+      path: "/chosen/path",
+    });
+    expect(vm.pathApply.status).toBe("success");
+  });
+
+  it("dialog returns null (cancelled) → applyModelPath is NOT called", async () => {
+    mockOpen.mockResolvedValue(null);
+
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+    await vm.browseModelPath();
+    await wrapper.vm.$nextTick();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith(
+      "apply_model_path",
+      expect.anything(),
+    );
+  });
+});

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -757,8 +757,9 @@ async function applyModelPath(path: string) {
     } else {
       pathApply.value = { status: "success", message: result.message };
       if (result.restarted) {
-        // Give Ollama a moment to come back up before re-fetching
+        // Attempt twice: once after 2s, again after 5s in case restart is slow
         setTimeout(() => modelsStore.fetchModels(), 2000);
+        setTimeout(() => modelsStore.fetchModels(), 5000);
       }
     }
   } catch (err: unknown) {
@@ -1000,7 +1001,11 @@ function confirmReset() {
     confirmLabel: "Reset",
     kind: "danger",
     onConfirm: async () => {
+      const hadCustomPath = !!settingsStore.modelPath;
       await settingsStore.resetToDefaults();
+      if (hadCustomPath) {
+        await applyModelPath("");
+      }
     },
   });
 }

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -760,19 +760,11 @@ async function applyModelPath(path: string) {
     } else {
       pathApply.value = { status: "success", message: result.message };
       if (result.restarted) {
-        // Hostname check used until Host gains a kind field (CL-host-type)
-        const isCloudUrl = (url: string) => {
-          try {
-            return new URL(url).hostname === "api.ollama.com";
-          } catch {
-            return false;
-          }
-        };
         const ensureLocalHost = async () => {
           await hostStore.fetchHosts();
           const active = hostStore.activeHost;
-          if (active && isCloudUrl(active.url)) {
-            const local = hostStore.hosts.find((h) => !isCloudUrl(h.url));
+          if (active && active.kind === "cloud") {
+            const local = hostStore.hosts.find((h) => h.kind === "local");
             if (local) await hostStore.setActiveHost(local.id);
           }
         };

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -640,9 +640,11 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import { useSettingsStore } from "../stores/settings";
+import { useModelsStore } from "../stores/models";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
+const modelsStore = useModelsStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
 
 // ── Model path feature ────────────────────────────────────────────────────────
@@ -754,6 +756,10 @@ async function applyModelPath(path: string) {
       pathApply.value = { status: "manual", message: result.message };
     } else {
       pathApply.value = { status: "success", message: result.message };
+      if (result.restarted) {
+        // Give Ollama a moment to come back up before re-fetching
+        setTimeout(() => modelsStore.fetchModels(), 2000);
+      }
     }
   } catch (err: unknown) {
     const msg =

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -760,6 +760,7 @@ async function applyModelPath(path: string) {
     } else {
       pathApply.value = { status: "success", message: result.message };
       if (result.restarted) {
+        // Hostname check used until Host gains a kind field (CL-host-type)
         const isCloudUrl = (url: string) => {
           try {
             return new URL(url).hostname === "api.ollama.com";

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -641,10 +641,12 @@ import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import { useSettingsStore } from "../stores/settings";
 import { useModelStore } from "../stores/models";
+import { useHostStore } from "../stores/hosts";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
 const modelsStore = useModelStore();
+const hostStore = useHostStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
 
 // ── Model path feature ────────────────────────────────────────────────────────
@@ -757,8 +759,21 @@ async function applyModelPath(path: string) {
     } else {
       pathApply.value = { status: "success", message: result.message };
       if (result.restarted) {
-        // Attempt twice: once after 2s, again after 5s in case restart is slow
-        setTimeout(() => modelsStore.fetchModels(), 2000);
+        // Model path is a local operation — ensure a local host is active before
+        // fetching models. If the cloud host is currently active, switch to a local
+        // host so list_models queries the restarted local Ollama.
+        const ensureLocalHost = async () => {
+          await hostStore.fetchHosts();
+          const active = hostStore.activeHost;
+          const isCloud = active?.url?.includes("api.ollama.com") ?? false;
+          if (isCloud) {
+            const local = hostStore.hosts.find(
+              (h) => !h.url.includes("api.ollama.com"),
+            );
+            if (local) await hostStore.setActiveHost(local.id);
+          }
+        };
+        setTimeout(async () => { await ensureLocalHost(); modelsStore.fetchModels(); }, 2000);
         setTimeout(() => modelsStore.fetchModels(), 5000);
       }
     }

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -543,7 +543,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, markRaw, h, type Component } from "vue";
+import { ref, computed, watch, markRaw, h, type Component } from "vue";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import ConfirmationModal from "../components/shared/ConfirmationModal.vue";
@@ -558,6 +558,98 @@ import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
+
+// ── Model path feature ────────────────────────────────────────────────────────
+
+interface ModelPathInfo {
+  resolved_path: string;
+  exists: boolean;
+  accessible: boolean;
+  model_count: number;
+}
+
+interface ApplyModelPathResult {
+  service_type: string;
+  applied: boolean;
+  restarted: boolean;
+  message: string;
+}
+
+interface ModelPathValidation {
+  status: "idle" | "checking" | "ok" | "warning" | "error";
+  message: string;
+  modelCount: number;
+}
+
+interface ModelPathApply {
+  status: "idle" | "applying" | "success" | "error" | "manual";
+  message: string;
+}
+
+const pathValidation = ref<ModelPathValidation>({
+  status: "idle",
+  message: "",
+  modelCount: 0,
+});
+
+const pathApply = ref<ModelPathApply>({
+  status: "idle",
+  message: "",
+});
+
+let _validateTimer: ReturnType<typeof setTimeout> | null = null;
+
+watch(
+  () => settingsStore.modelPath,
+  (newPath) => {
+    if (_validateTimer) clearTimeout(_validateTimer);
+    if (!newPath) {
+      pathValidation.value = { status: "idle", message: "", modelCount: 0 };
+      return;
+    }
+    pathValidation.value = { ...pathValidation.value, status: "checking" };
+    _validateTimer = setTimeout(async () => {
+      try {
+        const info = await invoke<ModelPathInfo>("validate_model_path", {
+          path: newPath,
+        });
+        if (!info.exists) {
+          pathValidation.value = {
+            status: "error",
+            message: "Path does not exist",
+            modelCount: 0,
+          };
+        } else if (!info.accessible) {
+          pathValidation.value = {
+            status: "ok",
+            message:
+              "System path — Alpaka will request elevated access to configure Ollama",
+            modelCount: 0,
+          };
+        } else if (info.model_count === 0) {
+          pathValidation.value = {
+            status: "warning",
+            message:
+              "No Ollama models found here — your current models won't be accessible at this location",
+            modelCount: 0,
+          };
+        } else {
+          pathValidation.value = {
+            status: "ok",
+            message: `Found ${info.model_count} model(s)`,
+            modelCount: info.model_count,
+          };
+        }
+      } catch {
+        pathValidation.value = {
+          status: "error",
+          message: "Validation failed",
+          modelCount: 0,
+        };
+      }
+    }, 500);
+  },
+);
 
 const themeOptions = [
   { id: "system" as const, label: "System", sub: "Follows OS" },

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -688,6 +688,7 @@ const pathApply = ref<ModelPathApply>({
 });
 
 let _validateTimer: ReturnType<typeof setTimeout> | null = null;
+const _restartTimers: ReturnType<typeof setTimeout>[] = [];
 
 watch(
   () => settingsStore.modelPath,
@@ -745,10 +746,10 @@ watch(
 
 onBeforeUnmount(() => {
   if (_validateTimer) clearTimeout(_validateTimer);
+  _restartTimers.forEach(clearTimeout);
 });
 
 async function applyModelPath(path: string) {
-  if (!path) return;
   pathApply.value = { status: "applying", message: "" };
   try {
     const result = await invoke<ApplyModelPathResult>("apply_model_path", {
@@ -762,6 +763,7 @@ async function applyModelPath(path: string) {
         // Model path is a local operation — ensure a local host is active before
         // fetching models. If the cloud host is currently active, switch to a local
         // host so list_models queries the restarted local Ollama.
+        // TODO(CL-host-type): replace URL substring check once Host gains a kind field
         const ensureLocalHost = async () => {
           await hostStore.fetchHosts();
           const active = hostStore.activeHost;
@@ -773,8 +775,13 @@ async function applyModelPath(path: string) {
             if (local) await hostStore.setActiveHost(local.id);
           }
         };
-        setTimeout(async () => { await ensureLocalHost(); modelsStore.fetchModels(); }, 2000);
-        setTimeout(() => modelsStore.fetchModels(), 5000);
+        _restartTimers.push(
+          setTimeout(async () => {
+            await ensureLocalHost();
+            modelsStore.fetchModels();
+          }, 2000),
+        );
+        _restartTimers.push(setTimeout(() => modelsStore.fetchModels(), 5000));
       }
     }
   } catch (err: unknown) {

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -697,7 +697,7 @@ watch(
           };
         } else if (!info.accessible) {
           pathValidation.value = {
-            status: "ok",
+            status: "warning",
             message:
               "System path — Alpaka will request elevated access to configure Ollama",
             modelCount: 0,
@@ -952,6 +952,10 @@ async function browseModelPath() {
     }
   } catch (err) {
     console.error("Failed to pick directory:", err);
+    pathApply.value = {
+      status: "error",
+      message: "Could not open directory picker",
+    };
   }
 }
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -543,7 +543,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, markRaw, h, type Component } from "vue";
+import { ref, computed, watch, onBeforeUnmount, markRaw, h, type Component } from "vue";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import ConfirmationModal from "../components/shared/ConfirmationModal.vue";
@@ -640,7 +640,8 @@ watch(
             modelCount: info.model_count,
           };
         }
-      } catch {
+      } catch (err) {
+        console.error("Model path validation failed:", err);
         pathValidation.value = {
           status: "error",
           message: "Validation failed",
@@ -650,6 +651,10 @@ watch(
     }, 500);
   },
 );
+
+onBeforeUnmount(() => {
+  if (_validateTimer) clearTimeout(_validateTimer);
+});
 
 const themeOptions = [
   { id: "system" as const, label: "System", sub: "Follows OS" },

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -763,15 +763,19 @@ async function applyModelPath(path: string) {
         // Model path is a local operation — ensure a local host is active before
         // fetching models. If the cloud host is currently active, switch to a local
         // host so list_models queries the restarted local Ollama.
-        // TODO(CL-host-type): replace URL substring check once Host gains a kind field
+        // TODO(CL-host-type): replace hostname check once Host gains a kind field
+        const isCloudUrl = (url: string) => {
+          try {
+            return new URL(url).hostname === "api.ollama.com";
+          } catch {
+            return false;
+          }
+        };
         const ensureLocalHost = async () => {
           await hostStore.fetchHosts();
           const active = hostStore.activeHost;
-          const isCloud = active?.url?.includes("api.ollama.com") ?? false;
-          if (isCloud) {
-            const local = hostStore.hosts.find(
-              (h) => !h.url.includes("api.ollama.com"),
-            );
+          if (active && isCloudUrl(active.url)) {
+            const local = hostStore.hosts.find((h) => !isCloudUrl(h.url));
             if (local) await hostStore.setActiveHost(local.id);
           }
         };

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -640,11 +640,11 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import { useSettingsStore } from "../stores/settings";
-import { useModelsStore } from "../stores/models";
+import { useModelStore } from "../stores/models";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
 
 const settingsStore = useSettingsStore();
-const modelsStore = useModelsStore();
+const modelsStore = useModelStore();
 const { modal, openModal, onConfirm, onCancel } = useConfirmationModal();
 
 // ── Model path feature ────────────────────────────────────────────────────────

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -760,10 +760,6 @@ async function applyModelPath(path: string) {
     } else {
       pathApply.value = { status: "success", message: result.message };
       if (result.restarted) {
-        // Model path is a local operation — ensure a local host is active before
-        // fetching models. If the cloud host is currently active, switch to a local
-        // host so list_models queries the restarted local Ollama.
-        // TODO(CL-host-type): replace hostname check once Host gains a kind field
         const isCloudUrl = (url: string) => {
           try {
             return new URL(url).hostname === "api.ollama.com";
@@ -784,8 +780,8 @@ async function applyModelPath(path: string) {
             await ensureLocalHost();
             modelsStore.fetchModels();
           }, 2000),
+          setTimeout(() => modelsStore.fetchModels(), 5000),
         );
-        _restartTimers.push(setTimeout(() => modelsStore.fetchModels(), 5000));
       }
     }
   } catch (err: unknown) {

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -208,14 +208,9 @@
               <template #control>
                 <input
                   v-model="settingsStore.modelPath"
-                  @change="
-                    settingsStore.updateSetting(
-                      'modelPath',
-                      settingsStore.modelPath,
-                    )
-                  "
+                  @change="applyModelPath(settingsStore.modelPath)"
                   placeholder="~/.ollama/models"
-                  class="custom-input w-36 font-mono"
+                  class="custom-input w-52 font-mono"
                 />
                 <button
                   @click="browseModelPath"
@@ -225,6 +220,87 @@
                 </button>
               </template>
             </SettingsRow>
+
+            <!-- Model path status panel -->
+            <div
+              v-if="pathValidation.status !== 'idle' || pathApply.status !== 'idle'"
+              class="flex flex-col gap-1 px-4 py-2 rounded-xl bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[11.5px]"
+            >
+              <!-- Validation feedback -->
+              <div
+                v-if="pathValidation.status === 'checking'"
+                class="flex items-center gap-1.5 text-[var(--text-dim)]"
+              >
+                <svg
+                  class="animate-spin w-3 h-3 flex-shrink-0"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+                Checking path…
+              </div>
+              <div
+                v-else-if="pathValidation.status === 'error'"
+                class="flex items-center gap-1.5 text-[var(--danger)]"
+              >
+                <span class="flex-shrink-0">⚠</span>
+                {{ pathValidation.message }}
+              </div>
+              <div
+                v-else-if="pathValidation.status === 'warning'"
+                class="flex items-center gap-1.5 text-amber-500"
+              >
+                <span class="flex-shrink-0">⚠</span>
+                {{ pathValidation.message }}
+              </div>
+              <div
+                v-else-if="pathValidation.status === 'ok'"
+                class="flex items-center gap-1.5 text-[var(--accent)]"
+              >
+                <span class="flex-shrink-0">✓</span>
+                {{ pathValidation.message }}
+              </div>
+
+              <!-- Apply feedback -->
+              <div
+                v-if="pathApply.status === 'applying'"
+                class="flex items-center gap-1.5 text-[var(--text-dim)]"
+              >
+                <svg
+                  class="animate-spin w-3 h-3 flex-shrink-0"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                >
+                  <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                </svg>
+                Applying…
+              </div>
+              <div
+                v-else-if="pathApply.status === 'success'"
+                class="flex items-center gap-1.5 text-[var(--accent)]"
+              >
+                <span class="flex-shrink-0">✓</span>
+                {{ pathApply.message }}
+              </div>
+              <div
+                v-else-if="pathApply.status === 'error'"
+                class="flex items-center gap-1.5 text-[var(--danger)]"
+              >
+                <span class="flex-shrink-0">✗</span>
+                {{ pathApply.message }}
+              </div>
+              <div
+                v-else-if="pathApply.status === 'manual'"
+                class="text-[var(--text-dim)]"
+              >
+                {{ pathApply.message }}
+              </div>
+            </div>
 
             <SettingsRow icon="layout">
               <template #label>Context length</template>
@@ -656,6 +732,27 @@ onBeforeUnmount(() => {
   if (_validateTimer) clearTimeout(_validateTimer);
 });
 
+async function applyModelPath(path: string) {
+  if (!path) return;
+  pathApply.value = { status: "applying", message: "" };
+  try {
+    const result = await invoke<ApplyModelPathResult>("apply_model_path", {
+      path,
+    });
+    if (result.service_type === "none") {
+      pathApply.value = { status: "manual", message: result.message };
+    } else {
+      pathApply.value = { status: "success", message: result.message };
+    }
+  } catch (err: unknown) {
+    const msg =
+      typeof err === "string"
+        ? err
+        : (err as { message?: string })?.message ?? "Unknown error";
+    pathApply.value = { status: "error", message: msg };
+  }
+}
+
 const themeOptions = [
   { id: "system" as const, label: "System", sub: "Follows OS" },
   { id: "light" as const, label: "Light", sub: "Always light" },
@@ -850,7 +947,8 @@ async function browseModelPath() {
   try {
     const selected = await open({ directory: true, multiple: false });
     if (selected && typeof selected === "string") {
-      await settingsStore.updateSetting("modelPath", selected);
+      settingsStore.modelPath = selected;
+      await applyModelPath(selected);
     }
   } catch (err) {
     console.error("Failed to pick directory:", err);

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -223,7 +223,9 @@
 
             <!-- Model path status panel -->
             <div
-              v-if="pathValidation.status !== 'idle' || pathApply.status !== 'idle'"
+              v-if="
+                pathValidation.status !== 'idle' || pathApply.status !== 'idle'
+              "
               class="flex flex-col gap-1 px-4 py-2 rounded-xl bg-[var(--bg-surface)] border border-[var(--border-subtle)] text-[11.5px]"
             >
               <!-- Validation feedback -->
@@ -619,7 +621,15 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onBeforeUnmount, markRaw, h, type Component } from "vue";
+import {
+  ref,
+  computed,
+  watch,
+  onBeforeUnmount,
+  markRaw,
+  h,
+  type Component,
+} from "vue";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import ConfirmationModal from "../components/shared/ConfirmationModal.vue";
@@ -726,6 +736,7 @@ watch(
       }
     }, 500);
   },
+  { immediate: true },
 );
 
 onBeforeUnmount(() => {
@@ -748,7 +759,7 @@ async function applyModelPath(path: string) {
     const msg =
       typeof err === "string"
         ? err
-        : (err as { message?: string })?.message ?? "Unknown error";
+        : ((err as { message?: string })?.message ?? "Unknown error");
     pathApply.value = { status: "error", message: msg };
   }
 }


### PR DESCRIPTION
## Summary

- Adds `validate_model_path` Tauri command: checks path existence, accessibility, and Ollama model count (via `manifests/` directory scan)
- Adds `apply_model_path` Tauri command: persists path to SQLite, detects service type, writes `OLLAMA_MODELS` systemd override, restarts Ollama
  - User service (`systemctl --user`): writes `~/.config/systemd/user/ollama.service.d/override.conf` directly
  - System service: single `pkexec` call (one password prompt) writes `/etc/systemd/system/ollama.service.d/override.conf`
  - Temp file written to `$XDG_RUNTIME_DIR` (not `/tmp`) to prevent symlink attacks
  - No service detected: returns env var instruction message
- Settings Engine tab: debounced live validation (path exists, model count, accessibility), apply-on-save via text blur and directory picker
- Status panel shows validation result and apply outcome inline

## Test plan
- [ ] Change model path to existing dir with models → green "Found N model(s)" after 500ms
- [ ] Change path to non-existent dir → red "Path does not exist"
- [ ] Change path to empty dir → amber "No Ollama models found here…" warning
- [ ] Inaccessible system path → amber "System path — Alpaka will request elevated access"
- [ ] Blur/change saves path and applies override to user service, restarts Ollama
- [ ] Browse button picks a dir and immediately applies
- [ ] System service user: pkexec prompt appears, service restarted after auth
- [ ] No service: amber env var instruction message shown

Closes #16