### PR TITLE
feat(settings): S-06 custom stop sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- S-06: Custom stop sequences — Settings → Advanced tab with a tag-input for up to 4 stop tokens (e.g. `###`, `<END>`). Sequences are sent as `options.stop` in every Ollama chat request; empty list omits the field entirely. Setting key allowlist added to the backend `set_setting` command.
 - MO-06: Custom model creation from Modelfile — create and edit Ollama models directly in the app with a CodeMirror editor, streaming progress, background creation, desktop notifications, and mid-stream cancellation (#22)
 - S-10: Per-model default generation settings — each installed model can have its own temperature, context window, and other generation defaults. Edit from the model detail page (Models → Local tab → click a model). Defaults auto-apply when selecting a model for a new or existing conversation. Save current chat settings as model defaults from the Advanced Options panel.
 - S-09: Per-conversation preset profiles for generation settings — four built-in presets (Creative, Balanced, Precise, Code), user-defined presets with save/delete, preset selection persisted per-chat via draft, default preset applied to new conversations. Advanced Options popover shows the active preset name.

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -104,7 +104,7 @@ A **first-class, lightweight Linux desktop client** for Ollama that:
 | S-03 | **System prompt editor** | P0 | ✅ | Per-conversation; stored as system role message |
 | S-04 | **Top-P / Top-K** | P0 | ✅ | Fine-grained sampling control |
 | S-05 | **Repeat penalty** | P0 | ✅ | repeat_penalty, repeat_last_n |
-| S-06 | **Stop sequences** | P1 | Backlog | Custom stop tokens |
+| S-06 | **Stop sequences** | P1 | ✅ | Custom stop tokens |
 | S-07 | **Seed control** | P1 | Backlog | Fixed seed for reproducible outputs |
 | S-08 | **Mirostat** | P1 | Backlog | Mirostat 1/2 with tau and eta |
 | S-09 | **Preset profiles** | P1 | Backlog | Save/load parameter presets |

--- a/src-tauri/src/commands/model_settings.rs
+++ b/src-tauri/src/commands/model_settings.rs
@@ -78,5 +78,17 @@ pub(crate) fn validate_chat_options(opts: &ChatOptions) -> Result<(), AppError> 
             ));
         }
     }
+    if let Some(ref stops) = opts.stop {
+        if stops.len() > 4 {
+            return Err(AppError::Validation(
+                "stop must contain at most 4 sequences".into(),
+            ));
+        }
+        if stops.iter().any(|s| s.len() > 256) {
+            return Err(AppError::Validation(
+                "each stop sequence must be 256 characters or fewer".into(),
+            ));
+        }
+    }
     Ok(())
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -5,6 +5,37 @@ use crate::db;
 use crate::error::AppError;
 use crate::state::AppState;
 
+const ALLOWED_SETTING_KEYS: &[&str] = &[
+    "theme",
+    "sidebarCollapsed",
+    "fontSize",
+    "compactMode",
+    "chatOptions",
+    "cloud",
+    "autoUpdate",
+    "exposeNetwork",
+    "modelPath",
+    "serverUrl",
+    "showPerformanceMetrics",
+    "notificationsEnabled",
+    "globalSystemPrompt",
+    "systemFormattingEnabled",
+    "systemFormattingTemplate",
+    "systemSearchTemplate",
+    "systemFolderTemplate",
+    "presets",
+    "defaultPresetId",
+    "userPresets",
+];
+
+fn validate_setting_key(key: &str) -> Result<(), AppError> {
+    if ALLOWED_SETTING_KEYS.contains(&key) {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!("unknown setting key: {key}")))
+    }
+}
+
 #[command]
 pub async fn get_setting(
     state: State<'_, AppState>,
@@ -19,6 +50,7 @@ pub async fn set_setting(
     key: String,
     value: String,
 ) -> Result<(), AppError> {
+    validate_setting_key(&key)?;
     db::settings::set_async(state.db.clone(), key, value).await
 }
 
@@ -31,6 +63,7 @@ pub async fn get_all_settings(
 
 #[command]
 pub async fn delete_setting(state: State<'_, AppState>, key: String) -> Result<(), AppError> {
+    validate_setting_key(&key)?;
     db::settings::delete_async(state.db.clone(), key).await
 }
 
@@ -47,7 +80,6 @@ mod tests {
 
     use crate::db::migrations;
 
-    // Helper to create an in-memory db with schema
     fn in_memory_db() -> db::DbConn {
         let conn = Connection::open_in_memory().unwrap();
         conn.execute_batch(
@@ -61,11 +93,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_settings_commands() {
-        // Because Tauri's `State` isn't easily instantiable outside of a running app context,
-        // we test the core logic that the commands run, using the exact same closure blocks.
         let db_conn = in_memory_db();
 
-        // set_setting logic
         let set_db = db_conn.clone();
         tokio::task::spawn_blocking(move || {
             let conn = set_db.lock().unwrap();
@@ -75,7 +104,6 @@ mod tests {
         .unwrap()
         .unwrap();
 
-        // get_setting logic
         let get_db = db_conn.clone();
         let val = tokio::task::spawn_blocking(move || {
             let conn = get_db.lock().unwrap();
@@ -86,7 +114,6 @@ mod tests {
         .unwrap();
         assert_eq!(val, Some("\"dark\"".to_owned()));
 
-        // get_all_settings logic
         let get_all_db = db_conn.clone();
         let all = tokio::task::spawn_blocking(move || {
             let conn = get_all_db.lock().unwrap();
@@ -97,5 +124,23 @@ mod tests {
         .unwrap();
         assert_eq!(all.len(), 1);
         assert_eq!(all["theme"], "\"dark\"");
+    }
+
+    #[test]
+    fn test_validate_setting_key_known_keys_pass() {
+        for key in ALLOWED_SETTING_KEYS {
+            assert!(
+                validate_setting_key(key).is_ok(),
+                "expected {key} to be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_setting_key_unknown_key_rejected() {
+        assert!(validate_setting_key("__proto__").is_err());
+        assert!(validate_setting_key("constructor").is_err());
+        assert!(validate_setting_key("arbitrary_key").is_err());
+        assert!(validate_setting_key("").is_err());
     }
 }

--- a/src-tauri/src/db/model_settings.rs
+++ b/src-tauri/src/db/model_settings.rs
@@ -22,6 +22,7 @@ pub fn get(conn: &Connection, model_name: &str) -> Result<Option<ChatOptions>, A
                 && opts.repeat_penalty.is_none()
                 && opts.repeat_last_n.is_none()
                 && opts.seed.is_none()
+                && opts.stop.is_none()
             {
                 Ok(None)
             } else {

--- a/src-tauri/src/ollama/types.rs
+++ b/src-tauri/src/ollama/types.rs
@@ -86,6 +86,8 @@ pub struct ChatOptions {
     pub repeat_last_n: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub seed: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Vec<String>>,
 }
 
 impl ChatOptions {
@@ -99,6 +101,7 @@ impl ChatOptions {
             repeat_penalty: self.repeat_penalty.or(fallback.repeat_penalty),
             repeat_last_n: self.repeat_last_n.or(fallback.repeat_last_n),
             seed: self.seed.or(fallback.seed),
+            stop: self.stop.clone().or_else(|| fallback.stop.clone()),
         }
     }
 }

--- a/src-tauri/src/services/chat.rs
+++ b/src-tauri/src/services/chat.rs
@@ -852,6 +852,52 @@ mod tests {
     }
 
     #[test]
+    fn stop_serializes_and_omitted_when_none() {
+        use crate::ollama::types::ChatOptions;
+        let opts = ChatOptions {
+            stop: None,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&opts).unwrap();
+        assert!(
+            !json.contains("stop"),
+            "stop must be omitted from JSON when None"
+        );
+    }
+
+    #[test]
+    fn stop_merge_custom_wins_fallback_fills() {
+        use crate::ollama::types::ChatOptions;
+        let global = ChatOptions {
+            stop: Some(vec!["###".to_string()]),
+            ..Default::default()
+        };
+        // custom with its own stop → custom wins
+        let custom_with_stop = ChatOptions {
+            stop: Some(vec!["<END>".to_string()]),
+            ..Default::default()
+        };
+        let merged = custom_with_stop.merge_with_fallback(&global);
+        assert_eq!(
+            merged.stop,
+            Some(vec!["<END>".to_string()]),
+            "custom stop wins"
+        );
+
+        // custom with no stop → global fills in
+        let custom_no_stop = ChatOptions {
+            stop: None,
+            ..Default::default()
+        };
+        let merged2 = custom_no_stop.merge_with_fallback(&global);
+        assert_eq!(
+            merged2.stop,
+            Some(vec!["###".to_string()]),
+            "global stop fills when custom absent"
+        );
+    }
+
+    #[test]
     fn sliding_window_keeps_system_and_recent_messages() {
         use crate::ollama::types::Message;
 

--- a/src/components/settings/StopSequencesInput.vue
+++ b/src/components/settings/StopSequencesInput.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="flex flex-col gap-2">
+    <div v-if="modelValue.length > 0" class="flex flex-wrap gap-1.5">
+      <span
+        v-for="(seq, idx) in modelValue"
+        :key="seq"
+        class="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-[var(--bg-active)] border border-[var(--border-strong)] text-[var(--text)] text-[11px] font-mono"
+      >
+        {{ seq }}
+        <button
+          type="button"
+          @click="remove(idx)"
+          class="text-[var(--text-dim)] hover:text-[var(--danger)] leading-none cursor-pointer border-none bg-transparent p-0 ml-0.5"
+          aria-label="Remove stop sequence"
+        >
+          ×
+        </button>
+      </span>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <input
+        v-model="draft"
+        :disabled="atLimit"
+        @keydown.enter.prevent="commit"
+        @keydown.tab="onTab"
+        :placeholder="
+          atLimit
+            ? `Limit reached (${MAX_STOP_SEQUENCES})`
+            : 'e.g. ###   Press Enter to add'
+        "
+        class="custom-input flex-1 font-mono text-[12px]"
+      />
+      <span class="text-[11px] text-[var(--text-dim)] shrink-0 tabular-nums">
+        {{ modelValue.length }}/{{ MAX_STOP_SEQUENCES }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from "vue";
+
+const MAX_STOP_SEQUENCES = 4;
+
+const props = defineProps<{ modelValue: string[] }>();
+const emit = defineEmits<{ "update:modelValue": [value: string[]] }>();
+
+const draft = ref("");
+
+const atLimit = computed(() => props.modelValue.length >= MAX_STOP_SEQUENCES);
+
+function commit() {
+  const trimmed = draft.value.trim();
+  if (!trimmed || atLimit.value) return;
+  if (props.modelValue.includes(trimmed)) {
+    draft.value = "";
+    return;
+  }
+  emit("update:modelValue", [...props.modelValue, trimmed]);
+  draft.value = "";
+}
+
+function onTab(e: KeyboardEvent) {
+  if (!draft.value.trim()) return;
+  e.preventDefault();
+  commit();
+}
+
+function remove(idx: number) {
+  const next = [...props.modelValue];
+  next.splice(idx, 1);
+  emit("update:modelValue", next);
+}
+</script>

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -44,6 +44,33 @@ describe("useSettingsStore", () => {
     expect(store.chatOptions.top_p).toBe(0.9);
   });
 
+  it("initialize restores stop sequences from chatOptions JSON blob", async () => {
+    const store = useSettingsStore();
+    mockInvoke.mockResolvedValue({
+      chatOptions: JSON.stringify({ temperature: 0.5, stop: ["###", "<END>"] }),
+    });
+
+    await store.initialize();
+
+    expect(store.chatOptions.stop).toEqual(["###", "<END>"]);
+  });
+
+  it("updateChatOptions serializes stop array into chatOptions JSON blob", async () => {
+    const store = useSettingsStore();
+    mockInvoke.mockResolvedValue({});
+    await store.initialize();
+
+    mockInvoke.mockResolvedValue(undefined);
+    await store.updateChatOptions({ stop: ["\\n\\n", "END"] });
+
+    const call = mockInvoke.mock.calls.find(
+      ([cmd]: [string]) => cmd === "set_setting",
+    );
+    expect(call).toBeDefined();
+    const serialized = JSON.parse(call![1].value as string);
+    expect(serialized.stop).toEqual(["\\n\\n", "END"]);
+  });
+
   it("initialize loads defaultPresetId from db", async () => {
     const store = useSettingsStore();
     mockInvoke.mockResolvedValue({ defaultPresetId: "code" });

--- a/src/views/SettingsPage.advanced.spec.ts
+++ b/src/views/SettingsPage.advanced.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import SettingsPage from "./SettingsPage.vue";
+import StopSequencesInput from "../components/settings/StopSequencesInput.vue";
+import { useSettingsStore } from "../stores/settings";
+
+const mockInvoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) =>
+    mockInvoke(cmd, args),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn().mockResolvedValue(null),
+}));
+
+// Stub heavy components with their own store/IPC dependencies
+vi.mock("../components/settings/HostSettings.vue", () => ({
+  default: { template: "<div />" },
+}));
+vi.mock("../components/settings/AccountSettings.vue", () => ({
+  default: { template: "<div />" },
+}));
+// StopSequencesInput is tested separately; stub it here to isolate SettingsPage logic
+vi.mock("../components/settings/StopSequencesInput.vue", () => ({
+  default: {
+    template: "<div data-testid='stop-sequences-input'></div>",
+    props: ["modelValue"],
+    emits: ["update:modelValue"],
+  },
+}));
+
+// AppTabs is NOT mocked so the real component renders — this exercises the
+// IconAdvanced setup() function which returns the gear SVG for the Advanced tab.
+
+function mountPage() {
+  return mount(SettingsPage, {
+    global: {
+      stubs: {
+        SettingsRow: { template: "<div><slot name='control' /></div>" },
+        ToggleSwitch: true,
+        SettingsSlider: true,
+        ConfirmationModal: true,
+        Transition: { template: "<div><slot /></div>" },
+      },
+    },
+  });
+}
+
+interface SettingsPageVM {
+  activeTab: string;
+}
+
+describe("SettingsPage — Advanced tab (S-06 stop sequences)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue([]);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("mounts with all 7 tabs rendered including Advanced", async () => {
+    const wrapper = mountPage();
+    await wrapper.vm.$nextTick();
+
+    const tabButtons = wrapper.findAll("button.app-tab");
+    const tabNames = tabButtons.map((b) => b.text());
+    expect(tabNames.some((t) => t.includes("Advanced"))).toBe(true);
+    expect(tabButtons.length).toBe(7);
+  });
+
+  it("Advanced tab section renders when activeTab is set to advanced", async () => {
+    const wrapper = mountPage();
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+
+    vm.activeTab = "advanced";
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find(".settings-card").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Stop Sequences");
+    expect(wrapper.text()).toContain("Custom tokens that end generation early");
+    expect(wrapper.find("[data-testid='stop-sequences-input']").exists()).toBe(
+      true,
+    );
+  });
+
+  it("StopSequencesInput receives stop sequences from store as modelValue", async () => {
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, stop: ["###", "<END>"] };
+
+    const wrapper = mountPage();
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+
+    vm.activeTab = "advanced";
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.findComponent(StopSequencesInput);
+    expect(input.props("modelValue")).toEqual(["###", "<END>"]);
+  });
+
+  it("update:modelValue with non-empty array calls updateChatOptions with that array", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const store = useSettingsStore();
+
+    const wrapper = mountPage();
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+
+    vm.activeTab = "advanced";
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.findComponent(StopSequencesInput);
+    await input.vm.$emit("update:modelValue", ["###"]);
+    await wrapper.vm.$nextTick();
+
+    expect(store.chatOptions.stop).toEqual(["###"]);
+  });
+
+  it("update:modelValue with empty array sets stop to undefined", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, stop: ["###"] };
+
+    const wrapper = mountPage();
+    const vm = wrapper.vm as unknown as SettingsPageVM;
+
+    vm.activeTab = "advanced";
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.findComponent(StopSequencesInput);
+    await input.vm.$emit("update:modelValue", []);
+    await wrapper.vm.$nextTick();
+
+    expect(store.chatOptions.stop).toBeUndefined();
+  });
+});

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="h-full overflow-y-auto px-6 py-5 no-scrollbar">
-    <div class="max-w-[620px] mx-auto">
+    <div class="max-w-[740px] mx-auto">
       <!-- Header row -->
       <div class="flex items-center gap-3 mb-1">
         <h1 class="text-[17px] font-bold text-[var(--text-heading)]">
@@ -625,6 +625,34 @@
               </template>
             </SettingsRow>
           </div>
+
+          <!-- Advanced Section -->
+          <div
+            v-else-if="activeTab === 'advanced'"
+            key="advanced"
+            class="flex flex-col gap-[8px]"
+          >
+            <div class="settings-card">
+              <div>
+                <p class="text-[13.5px] font-bold text-[var(--text)]">
+                  Stop Sequences
+                </p>
+                <p class="text-[12px] text-[var(--text-dim)] mt-0.5">
+                  Custom tokens that end generation early. Up to 4 sequences.
+                </p>
+              </div>
+              <div class="mt-3">
+                <StopSequencesInput
+                  :model-value="settingsStore.chatOptions.stop ?? []"
+                  @update:model-value="
+                    settingsStore.updateChatOptions({
+                      stop: $event.length ? $event : undefined,
+                    })
+                  "
+                />
+              </div>
+            </div>
+          </div>
         </Transition>
       </div>
     </div>
@@ -663,6 +691,7 @@ import SettingsRow from "../components/settings/SettingsRow.vue";
 import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
+import StopSequencesInput from "../components/settings/StopSequencesInput.vue";
 import { useSettingsStore } from "../stores/settings";
 import type { PresetOptions } from "../types/settings";
 import { useModelStore } from "../stores/models";
@@ -1056,6 +1085,31 @@ const IconBackup = markRaw({
   },
 });
 
+const IconAdvanced = markRaw({
+  setup() {
+    return () =>
+      h(
+        "svg",
+        {
+          width: 14,
+          height: 14,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          "stroke-width": 2,
+          "stroke-linecap": "round",
+          "stroke-linejoin": "round",
+        },
+        [
+          h("circle", { cx: 12, cy: 12, r: 3 }),
+          h("path", {
+            d: "M19.07 4.93a10 10 0 0 1 0 14.14M4.93 4.93a10 10 0 0 0 0 14.14",
+          }),
+        ],
+      );
+  },
+});
+
 const tabs: Tab[] = [
   { id: "general", name: "General", icon: IconGeneral },
   { id: "connectivity", name: "Connection", icon: IconConnect },
@@ -1063,6 +1117,7 @@ const tabs: Tab[] = [
   { id: "prompts", name: "Prompts", icon: IconPrompts },
   { id: "account", name: "Account", icon: IconAccount },
   { id: "maintenance", name: "Maintenance", icon: IconBackup },
+  { id: "advanced", name: "Advanced", icon: IconAdvanced },
 ];
 
 // ---- Model path ----


### PR DESCRIPTION
## Summary

- Adds a new **Advanced** tab to the Settings page with a tag-input for up to 4 custom stop sequences (e.g. `###`, `<END>`, `\n\n`)
- Stop sequences are serialized into every Ollama `/api/chat` request as `options.stop`; an empty list omits the field entirely (preserves Ollama default behaviour)
- Rust `ChatOptions` struct gains a `stop: Option<Vec<String>>` field with correct serde skip and `merge_with_fallback` handling; `validate_chat_options` enforces the 4-item and 256-char limits server-side

Closes #19

## Test Plan

- [x] Open Settings → Advanced tab appears without tab bar overflow
- [x] Type a sequence and press Enter — pill appears; type duplicate — silently ignored
- [x] Add 4 sequences — counter shows `4/4`, input is disabled
- [x] Close and reopen Settings — sequences persist
- [x] Send a chat message — verify `stop` array appears in the Ollama request options
- [x] Remove all sequences — next request sends no `stop` field
- [x] `pnpm test` passes (483 tests)
- [x] `cargo test` passes