### PR TITLE
feat(S-08): Mirostat v1/v2 sampling controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- S-08: Mirostat v1/v2 sampling controls in Advanced Chat Options — Mirostat mode selector (Off/Mirostat 1/Mirostat 2) with tau (default 5.0) and eta (default 0.1) sliders; top-p/top-k hidden when Mirostat is active
 - S-06: Custom stop sequences — Settings → Advanced tab with a tag-input for up to 4 stop tokens (e.g. `###`, `<END>`). Sequences are sent as `options.stop` in every Ollama chat request; empty list omits the field entirely. Setting key allowlist added to the backend `set_setting` command.
 - MO-06: Custom model creation from Modelfile — create and edit Ollama models directly in the app with a CodeMirror editor, streaming progress, background creation, desktop notifications, and mid-stream cancellation (#22)
 - S-10: Per-model default generation settings — each installed model can have its own temperature, context window, and other generation defaults. Edit from the model detail page (Models → Local tab → click a model). Defaults auto-apply when selecting a model for a new or existing conversation. Save current chat settings as model defaults from the Advanced Options panel.

--- a/src-tauri/src/db/model_settings.rs
+++ b/src-tauri/src/db/model_settings.rs
@@ -23,6 +23,9 @@ pub fn get(conn: &Connection, model_name: &str) -> Result<Option<ChatOptions>, A
                 && opts.repeat_last_n.is_none()
                 && opts.seed.is_none()
                 && opts.stop.is_none()
+                && opts.mirostat.is_none()
+                && opts.mirostat_tau.is_none()
+                && opts.mirostat_eta.is_none()
             {
                 Ok(None)
             } else {
@@ -175,5 +178,25 @@ mod tests {
             .unwrap();
         assert!(result.is_some());
         assert_eq!(result.unwrap().temperature, Some(0.3));
+    }
+
+    #[test]
+    fn test_mirostat_only_settings_not_treated_as_empty() {
+        let conn = in_memory_db();
+        let opts = ChatOptions {
+            mirostat: Some(2),
+            mirostat_tau: Some(5.0),
+            mirostat_eta: Some(0.1),
+            ..Default::default()
+        };
+        set(&conn, "mirostat-model:latest", &opts).unwrap();
+        let result = get(&conn, "mirostat-model:latest").unwrap();
+        assert!(
+            result.is_some(),
+            "mirostat-only settings should not be treated as empty"
+        );
+        let retrieved = result.unwrap();
+        assert_eq!(retrieved.mirostat, Some(2));
+        assert_eq!(retrieved.mirostat_tau, Some(5.0));
     }
 }

--- a/src-tauri/src/ollama/types.rs
+++ b/src-tauri/src/ollama/types.rs
@@ -88,6 +88,12 @@ pub struct ChatOptions {
     pub seed: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stop: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirostat: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirostat_tau: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mirostat_eta: Option<f32>,
 }
 
 impl ChatOptions {
@@ -102,6 +108,9 @@ impl ChatOptions {
             repeat_last_n: self.repeat_last_n.or(fallback.repeat_last_n),
             seed: self.seed.or(fallback.seed),
             stop: self.stop.clone().or_else(|| fallback.stop.clone()),
+            mirostat: self.mirostat.or(fallback.mirostat),
+            mirostat_tau: self.mirostat_tau.or(fallback.mirostat_tau),
+            mirostat_eta: self.mirostat_eta.or(fallback.mirostat_eta),
         }
     }
 }
@@ -222,6 +231,47 @@ mod tests {
             Some("I should reason carefully here")
         );
         assert_eq!(resp.message.content, "");
+    }
+
+    #[test]
+    fn test_mirostat_fields_serialized_when_set() {
+        let opts = ChatOptions {
+            mirostat: Some(2),
+            mirostat_tau: Some(5.0),
+            mirostat_eta: Some(0.1),
+            ..Default::default()
+        };
+        let val = serde_json::to_value(&opts).unwrap();
+        assert_eq!(val["mirostat"], 2);
+        assert!((val["mirostat_tau"].as_f64().unwrap() - 5.0).abs() < 1e-5);
+        assert!((val["mirostat_eta"].as_f64().unwrap() - 0.1).abs() < 1e-5);
+    }
+
+    #[test]
+    fn test_mirostat_fields_omitted_when_none() {
+        let opts = ChatOptions::default();
+        let val = serde_json::to_value(&opts).unwrap();
+        assert!(val.get("mirostat").is_none());
+        assert!(val.get("mirostat_tau").is_none());
+        assert!(val.get("mirostat_eta").is_none());
+    }
+
+    #[test]
+    fn test_merge_with_fallback_mirostat() {
+        let primary = ChatOptions {
+            mirostat: Some(1),
+            ..Default::default()
+        };
+        let fallback = ChatOptions {
+            mirostat: Some(2),
+            mirostat_tau: Some(5.0),
+            mirostat_eta: Some(0.1),
+            ..Default::default()
+        };
+        let merged = primary.merge_with_fallback(&fallback);
+        assert_eq!(merged.mirostat, Some(1)); // primary wins
+        assert_eq!(merged.mirostat_tau, Some(5.0)); // fallback fills in
+        assert_eq!(merged.mirostat_eta, Some(0.1)); // fallback fills in
     }
 
     #[test]

--- a/src/components/chat/ChatInput.spec.ts
+++ b/src/components/chat/ChatInput.spec.ts
@@ -412,6 +412,115 @@ describe("ChatInput — Submission", () => {
   });
 });
 
+describe("ChatInput — parseChatOptionsJson mirostat fields", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockImplementation(() => Promise.resolve(undefined));
+  });
+
+  it("restores mirostat=1 from settings_json when loading a conversation", async () => {
+    const chatStore = useChatStore();
+    const conv = makeConversation("llama3");
+    conv.settings_json = JSON.stringify({
+      mirostat: 1,
+      mirostat_tau: 3.5,
+      mirostat_eta: 0.05,
+    });
+    chatStore.conversations.push(conv);
+    chatStore.activeConversationId = "conv-test-1";
+
+    const wrapper = mountInput();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      chatOptions: Record<string, unknown>;
+    };
+    expect(vm.chatOptions.mirostat).toBe(1);
+    expect(vm.chatOptions.mirostat_tau).toBe(3.5);
+    expect(vm.chatOptions.mirostat_eta).toBe(0.05);
+  });
+
+  it("restores mirostat=0 (Off) from settings_json", async () => {
+    const chatStore = useChatStore();
+    const conv = makeConversation("llama3");
+    conv.settings_json = JSON.stringify({ mirostat: 0, temperature: 0.5 });
+    chatStore.conversations.push(conv);
+    chatStore.activeConversationId = "conv-test-1";
+
+    const wrapper = mountInput();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      chatOptions: Record<string, unknown>;
+    };
+    expect(vm.chatOptions.mirostat).toBe(0);
+    expect(vm.chatOptions.temperature).toBe(0.5);
+  });
+
+  it("ignores invalid mirostat values from settings_json", async () => {
+    const chatStore = useChatStore();
+    const conv = makeConversation("llama3");
+    conv.settings_json = JSON.stringify({ mirostat: 99, temperature: 0.7 });
+    chatStore.conversations.push(conv);
+    chatStore.activeConversationId = "conv-test-1";
+
+    const wrapper = mountInput();
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as {
+      chatOptions: Record<string, unknown>;
+    };
+    expect(vm.chatOptions.mirostat).toBeUndefined();
+    expect(vm.chatOptions.temperature).toBe(0.7);
+  });
+});
+
+describe("ChatInput — loadDraft applies model defaults when no settings_json", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("applies model defaults (including mirostat) when conversation has no settings_json", async () => {
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_model_defaults")
+        return Promise.resolve({
+          mirostat: 2,
+          mirostat_tau: 4.0,
+          mirostat_eta: 0.1,
+        });
+      if (cmd === "get_model_capabilities")
+        return Promise.resolve({
+          vision: false,
+          tools: false,
+          thinking: false,
+          thinking_toggleable: false,
+          thinking_levels: [],
+        });
+      return Promise.resolve(undefined);
+    });
+
+    const chatStore = useChatStore();
+    const conv = makeConversation("qwen2.5:7b");
+    conv.settings_json = "{}";
+    chatStore.conversations.push(conv);
+    chatStore.activeConversationId = "conv-test-1";
+
+    const wrapper = mountInput();
+    await wrapper.vm.$nextTick();
+    // allow async loadDraft to resolve
+    await new Promise((r) => setTimeout(r, 0));
+
+    const vm = wrapper.vm as unknown as {
+      chatOptions: Record<string, unknown>;
+    };
+    expect(mockInvoke).toHaveBeenCalledWith("get_model_defaults", {
+      modelName: "qwen2.5:7b",
+    });
+    expect(vm.chatOptions.mirostat).toBe(2);
+    expect(vm.chatOptions.mirostat_tau).toBe(4.0);
+  });
+});
+
 describe("ChatInput — Model defaults on selection", () => {
   beforeEach(() => {
     setActivePinia(createPinia());

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -209,6 +209,12 @@ function parseChatOptionsJson(raw: string): Partial<ChatOptions> | null {
       out.repeat_penalty = obj.repeat_penalty;
     if (typeof obj.repeat_last_n === "number")
       out.repeat_last_n = obj.repeat_last_n;
+    if (obj.mirostat === 0 || obj.mirostat === 1 || obj.mirostat === 2)
+      out.mirostat = obj.mirostat;
+    if (typeof obj.mirostat_tau === "number")
+      out.mirostat_tau = obj.mirostat_tau;
+    if (typeof obj.mirostat_eta === "number")
+      out.mirostat_eta = obj.mirostat_eta;
     return out;
   } catch {
     return null;
@@ -405,56 +411,77 @@ async function handleCompact() {
 
 // ---- Draft Sync Logic ----
 
-function loadDraft() {
-  if (!activeConvId.value) return;
-  isSyncingDraft.value = true;
-  const draft = chatStore.drafts[activeConvId.value];
-  if (draft) {
-    inputContent.value = draft.content;
-    webSearchEnabled.value = draft.webSearchEnabled;
-    thinkEnabled.value = draft.thinkEnabled;
-    thinkLevel.value = draft.thinkLevel;
-    chatOptions.value = draft.chatOptions || {};
-    presetId.value = draft.presetId ?? "";
+function applyDraft(
+  draft: (typeof chatStore.drafts)[string],
+  convIdAtLoad: string,
+) {
+  inputContent.value = draft.content;
+  webSearchEnabled.value = draft.webSearchEnabled;
+  thinkEnabled.value = draft.thinkEnabled;
+  thinkLevel.value = draft.thinkLevel;
+  chatOptions.value = draft.chatOptions || {};
+  presetId.value = draft.presetId ?? "";
+  clearAttachments();
+  attachments.value = draft.attachments.map((a) => {
+    const data = base64ToUint8Array(a.data);
+    const blob = new Blob([data], { type: a.type });
+    return {
+      file: new File([blob], a.name, { type: a.type }),
+      previewUrl: URL.createObjectURL(blob),
+      data,
+    };
+  });
+  if (draft.linkedContexts) {
+    chatStore.folderContexts[convIdAtLoad] = draft.linkedContexts;
+  }
+}
 
-    // Restore attachments
-    clearAttachments();
-    attachments.value = draft.attachments.map((a) => {
-      const data = base64ToUint8Array(a.data);
-      const blob = new Blob([data], { type: a.type });
-      const previewUrl = URL.createObjectURL(blob);
-      return {
-        file: new File([blob], a.name, { type: a.type }),
-        previewUrl,
-        data,
-      };
-    });
-
-    // Restore linked contexts
-    if (draft.linkedContexts) {
-      chatStore.folderContexts[activeConvId.value] = draft.linkedContexts;
-    }
-  } else {
-    // Reset if no draft — restore chatOptions from conversation's settings_json if present
-    inputContent.value = "";
-    clearAttachments();
-    webSearchEnabled.value = false;
-    thinkEnabled.value = false;
-    thinkLevel.value = "medium";
-    const conv = chatStore.conversations.find(
-      (c) => c.id === activeConvId.value,
-    );
-    const savedSettings = conv?.settings_json
-      ? parseChatOptionsJson(conv.settings_json)
-      : null;
-    if (savedSettings && Object.keys(savedSettings).length > 0) {
-      chatOptions.value = savedSettings;
+async function applyNoDraftSettings(convIdAtLoad: string) {
+  inputContent.value = "";
+  clearAttachments();
+  webSearchEnabled.value = false;
+  thinkEnabled.value = false;
+  thinkLevel.value = "medium";
+  const conv = chatStore.conversations.find((c) => c.id === convIdAtLoad);
+  const savedSettings = conv?.settings_json
+    ? parseChatOptionsJson(conv.settings_json)
+    : null;
+  if (savedSettings && Object.keys(savedSettings).length > 0) {
+    chatOptions.value = savedSettings;
+    presetId.value = "";
+    return;
+  }
+  // No saved settings — apply model defaults so per-model options (e.g. mirostat)
+  // survive across conversation switches even when the model name hasn't changed.
+  const modelName = activeModelName.value;
+  if (!modelName || modelName === "Select model") {
+    resetChatOptions();
+    return;
+  }
+  try {
+    const defaults = await applyModelDefaults(modelName);
+    if (activeConvId.value !== convIdAtLoad) return;
+    if (Object.keys(defaults).length > 0) {
+      chatOptions.value = defaults;
       presetId.value = "";
     } else {
       resetChatOptions();
     }
+  } catch {
+    resetChatOptions();
   }
+}
 
+async function loadDraft() {
+  if (!activeConvId.value) return;
+  const convIdAtLoad = activeConvId.value;
+  isSyncingDraft.value = true;
+  const draft = chatStore.drafts[convIdAtLoad];
+  if (draft) {
+    applyDraft(draft, convIdAtLoad);
+  } else {
+    await applyNoDraftSettings(convIdAtLoad);
+  }
   nextTick(() => {
     isSyncingDraft.value = false;
   });

--- a/src/components/chat/ChatView.vue
+++ b/src/components/chat/ChatView.vue
@@ -213,6 +213,7 @@ import { useSettingsStore } from "../../stores/settings";
 import { useAppOrchestration } from "../../composables/useAppOrchestration";
 import { useSendMessage } from "../../composables/useSendMessage";
 import type { Message } from "../../types/chat";
+import type { ChatOptions } from "../../types/settings";
 
 interface ScrollerItem {
   id: string;
@@ -369,9 +370,10 @@ async function onSend(
   images?: Uint8Array[],
   webSearchEnabled?: boolean,
   thinkMode?: string,
+  chatOptions?: ChatOptions,
 ) {
   isAutoScrollEnabled.value = true;
-  await sendMessage(text, images, webSearchEnabled, thinkMode);
+  await sendMessage(text, images, webSearchEnabled, thinkMode, chatOptions);
 }
 
 async function onStop() {

--- a/src/components/chat/input/AdvancedChatOptions.spec.ts
+++ b/src/components/chat/input/AdvancedChatOptions.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+import AdvancedChatOptions from "./AdvancedChatOptions.vue";
+import type { ChatOptions } from "../../../types/settings";
+
+function mountComponent(modelValue: Partial<ChatOptions> = {}, presetId = "") {
+  return mount(AdvancedChatOptions, {
+    props: { modelValue, presetId },
+    global: { plugins: [createPinia()] },
+  });
+}
+
+describe("AdvancedChatOptions — Mirostat controls", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("shows Off/Mirostat1/Mirostat2 buttons", () => {
+    const wrapper = mountComponent();
+    const buttons = wrapper
+      .findAll("button")
+      .filter((b) => ["Off", "Mirostat 1", "Mirostat 2"].includes(b.text()));
+    expect(buttons).toHaveLength(3);
+  });
+
+  it("Off is active by default when no mirostat in modelValue", () => {
+    const wrapper = mountComponent({});
+    const offBtn = wrapper.findAll("button").find((b) => b.text() === "Off")!;
+    expect(offBtn.classes()).toContain("bg-[var(--accent)]");
+  });
+
+  it("emits update:modelValue with mirostat=1 when Mirostat 1 clicked", async () => {
+    const wrapper = mountComponent({});
+    const btn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Mirostat 1")!;
+    await btn.trigger("click");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect((emitted![0][0] as Partial<ChatOptions>).mirostat).toBe(1);
+  });
+
+  it("emits update:modelValue with mirostat=2 when Mirostat 2 clicked", async () => {
+    const wrapper = mountComponent({});
+    const btn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Mirostat 2")!;
+    await btn.trigger("click");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect((emitted![0][0] as Partial<ChatOptions>).mirostat).toBe(2);
+  });
+
+  it("emits update:modelValue with mirostat=0 when Off clicked", async () => {
+    const wrapper = mountComponent({ mirostat: 2 });
+    const offBtn = wrapper.findAll("button").find((b) => b.text() === "Off")!;
+    await offBtn.trigger("click");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect((emitted![0][0] as Partial<ChatOptions>).mirostat).toBe(0);
+  });
+
+  it("hides Top P and Top K sliders when mirostat is active", () => {
+    const wrapper = mountComponent({ mirostat: 1 });
+    // SettingsSlider renders with a label prop — find by label text in rendered output
+    const html = wrapper.html();
+    // Top P label should not appear
+    expect(html).not.toContain("Top P");
+    expect(html).not.toContain("Top K");
+    // Tau and Eta labels should appear
+    expect(html).toContain("Mirostat Tau");
+    expect(html).toContain("Mirostat Eta");
+  });
+
+  it("shows Top P and Top K when mirostat is Off", () => {
+    const wrapper = mountComponent({ mirostat: 0 });
+    const html = wrapper.html();
+    expect(html).toContain("Top P");
+    expect(html).toContain("Top K");
+    expect(html).not.toContain("Mirostat Tau");
+    expect(html).not.toContain("Mirostat Eta");
+  });
+});

--- a/src/components/chat/input/AdvancedChatOptions.vue
+++ b/src/components/chat/input/AdvancedChatOptions.vue
@@ -164,6 +164,12 @@
     <div
       class="border-t border-[var(--border-subtle)] pt-2 flex flex-col gap-4"
     >
+      <MirostatSelector
+        :model-value="effectiveMirostat"
+        compact
+        @update:model-value="updateMirostat"
+      />
+
       <SettingsSlider
         label="Temperature"
         :model-value="
@@ -177,6 +183,7 @@
       />
 
       <SettingsSlider
+        v-if="effectiveMirostat === 0"
         label="Top P"
         :model-value="modelValue.top_p ?? settingsStore.chatOptions.top_p"
         @update:model-value="updateOption('top_p', $event)"
@@ -187,12 +194,41 @@
       />
 
       <SettingsSlider
+        v-if="effectiveMirostat === 0"
         label="Top K"
         :model-value="modelValue.top_k ?? settingsStore.chatOptions.top_k"
         @update:model-value="updateOption('top_k', $event)"
         :min="0"
         :max="500"
         :step="1"
+        compact
+      />
+
+      <SettingsSlider
+        v-if="effectiveMirostat !== 0"
+        label="Mirostat Tau"
+        :model-value="
+          modelValue.mirostat_tau ?? settingsStore.chatOptions.mirostat_tau ?? 5
+        "
+        @update:model-value="updateOption('mirostat_tau', $event)"
+        :min="0.1"
+        :max="10"
+        :step="0.1"
+        compact
+      />
+
+      <SettingsSlider
+        v-if="effectiveMirostat !== 0"
+        label="Mirostat Eta"
+        :model-value="
+          modelValue.mirostat_eta ??
+          settingsStore.chatOptions.mirostat_eta ??
+          0.1
+        "
+        @update:model-value="updateOption('mirostat_eta', $event)"
+        :min="0.01"
+        :max="1"
+        :step="0.01"
         compact
       />
 
@@ -228,6 +264,7 @@ import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
 import { useSettingsStore } from "../../../stores/settings";
 import type { ChatOptions, PresetOptions } from "../../../types/settings";
 import SettingsSlider from "../../settings/SettingsSlider.vue";
+import MirostatSelector from "../../shared/MirostatSelector.vue";
 import { useModelDefaults } from "../../../composables/useModelDefaults";
 
 const props = defineProps<{
@@ -254,6 +291,10 @@ const saveDefaultError = ref(false);
 
 const isPresetOpen = ref(false);
 const presetDropdownRef = ref<HTMLElement | null>(null);
+
+const effectiveMirostat = computed(
+  () => props.modelValue.mirostat ?? settingsStore.chatOptions.mirostat ?? 0,
+);
 
 const currentPresetLabel = computed(() => {
   if (!props.presetId) return "Custom";
@@ -294,6 +335,27 @@ function updateOption(key: keyof ChatOptions, value: number) {
   emit("update:presetId", "");
 }
 
+function updateMirostat(value: 0 | 1 | 2) {
+  emit("update:modelValue", { ...props.modelValue, mirostat: value });
+  emit("update:presetId", "");
+}
+
+function resolveCurrentOptions(): PresetOptions {
+  const mv = props.modelValue;
+  const defaults = settingsStore.chatOptions;
+  return {
+    temperature: mv.temperature ?? defaults.temperature,
+    top_p: mv.top_p ?? defaults.top_p,
+    top_k: mv.top_k ?? defaults.top_k,
+    num_ctx: mv.num_ctx ?? defaults.num_ctx,
+    repeat_penalty: mv.repeat_penalty ?? defaults.repeat_penalty,
+    repeat_last_n: mv.repeat_last_n ?? defaults.repeat_last_n,
+    mirostat: mv.mirostat ?? defaults.mirostat,
+    mirostat_tau: mv.mirostat_tau ?? defaults.mirostat_tau,
+    mirostat_eta: mv.mirostat_eta ?? defaults.mirostat_eta,
+  };
+}
+
 async function startSave() {
   saving.value = true;
   saveName.value = "";
@@ -303,37 +365,14 @@ async function startSave() {
 
 async function commitSave() {
   if (!saveName.value.trim()) return;
-  const options: PresetOptions = {
-    temperature:
-      props.modelValue.temperature ?? settingsStore.chatOptions.temperature,
-    top_p: props.modelValue.top_p ?? settingsStore.chatOptions.top_p,
-    top_k: props.modelValue.top_k ?? settingsStore.chatOptions.top_k,
-    num_ctx: props.modelValue.num_ctx ?? settingsStore.chatOptions.num_ctx,
-    repeat_penalty:
-      props.modelValue.repeat_penalty ??
-      settingsStore.chatOptions.repeat_penalty,
-    repeat_last_n:
-      props.modelValue.repeat_last_n ?? settingsStore.chatOptions.repeat_last_n,
-  };
-  await settingsStore.saveAsPreset(saveName.value, options);
+  await settingsStore.saveAsPreset(saveName.value, resolveCurrentOptions());
   saving.value = false;
   saveName.value = "";
 }
 
 async function handleSaveAsModelDefault() {
   if (!props.model || savingDefault.value) return;
-  const effective: Partial<ChatOptions> = {
-    temperature:
-      props.modelValue.temperature ?? settingsStore.chatOptions.temperature,
-    top_p: props.modelValue.top_p ?? settingsStore.chatOptions.top_p,
-    top_k: props.modelValue.top_k ?? settingsStore.chatOptions.top_k,
-    num_ctx: props.modelValue.num_ctx ?? settingsStore.chatOptions.num_ctx,
-    repeat_penalty:
-      props.modelValue.repeat_penalty ??
-      settingsStore.chatOptions.repeat_penalty,
-    repeat_last_n:
-      props.modelValue.repeat_last_n ?? settingsStore.chatOptions.repeat_last_n,
-  };
+  const effective = resolveCurrentOptions();
   savingDefault.value = true;
   saveDefaultError.value = false;
   savedAsDefault.value = false;

--- a/src/components/models/LocalModelDetails.spec.ts
+++ b/src/components/models/LocalModelDetails.spec.ts
@@ -84,3 +84,70 @@ describe("LocalModelDetails", () => {
     );
   });
 });
+
+describe("LocalModelDetails — Mirostat controls (S-08)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("renders Sampling Mode selector with Off/Mirostat1/Mirostat2 buttons", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockResolvedValue(null);
+
+    const wrapper = mount(LocalModelDetails, { props: { model: mockModel } });
+    await flushPromises();
+
+    const buttons = wrapper
+      .findAll("button")
+      .filter((b) => ["Off", "Mirostat 1", "Mirostat 2"].includes(b.text()));
+    expect(buttons).toHaveLength(3);
+  });
+
+  it("clicking Mirostat 2 sets effectiveMirostat to 2", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockResolvedValue(null);
+
+    const wrapper = mount(LocalModelDetails, { props: { model: mockModel } });
+    await flushPromises();
+
+    const btn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Mirostat 2")!;
+    await btn.trigger("click");
+    await wrapper.vm.$nextTick();
+
+    const vm = wrapper.vm as unknown as { effectiveMirostat: number };
+    expect(vm.effectiveMirostat).toBe(2);
+  });
+
+  it("loads mirostat defaults from stored model settings", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockResolvedValue({
+      mirostat: 1,
+      mirostat_tau: 6.0,
+      mirostat_eta: 0.2,
+    });
+
+    const wrapper = mount(LocalModelDetails, { props: { model: mockModel } });
+    await flushPromises();
+
+    const vm = wrapper.vm as unknown as {
+      effectiveMirostat: number;
+      edited: { mirostat?: number; mirostat_tau?: number };
+    };
+    expect(vm.effectiveMirostat).toBe(1);
+    expect(vm.edited.mirostat_tau).toBe(6.0);
+  });
+
+  it("effectiveMirostat defaults to 0 when no stored defaults", async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    vi.mocked(invoke).mockResolvedValue(null);
+
+    const wrapper = mount(LocalModelDetails, { props: { model: mockModel } });
+    await flushPromises();
+
+    const vm = wrapper.vm as unknown as { effectiveMirostat: number };
+    expect(vm.effectiveMirostat).toBe(0);
+  });
+});

--- a/src/components/models/LocalModelDetails.vue
+++ b/src/components/models/LocalModelDetails.vue
@@ -129,6 +129,10 @@
       </div>
 
       <div v-else class="flex flex-col gap-5">
+        <MirostatSelector
+          :model-value="effectiveMirostat"
+          @update:model-value="updateMirostat"
+        />
         <SettingsSlider
           label="Temperature"
           :model-value="
@@ -140,6 +144,7 @@
           :step="0.05"
         />
         <SettingsSlider
+          v-if="effectiveMirostat === 0"
           label="Top P"
           :model-value="edited.top_p ?? settingsStore.chatOptions.top_p"
           @update:model-value="edited = { ...edited, top_p: $event }"
@@ -148,12 +153,35 @@
           :step="0.05"
         />
         <SettingsSlider
+          v-if="effectiveMirostat === 0"
           label="Top K"
           :model-value="edited.top_k ?? settingsStore.chatOptions.top_k"
           @update:model-value="edited = { ...edited, top_k: $event }"
           :min="0"
           :max="500"
           :step="1"
+        />
+        <SettingsSlider
+          v-if="effectiveMirostat !== 0"
+          label="Mirostat Tau"
+          :model-value="
+            edited.mirostat_tau ?? settingsStore.chatOptions.mirostat_tau ?? 5
+          "
+          @update:model-value="edited = { ...edited, mirostat_tau: $event }"
+          :min="0.1"
+          :max="10"
+          :step="0.1"
+        />
+        <SettingsSlider
+          v-if="effectiveMirostat !== 0"
+          label="Mirostat Eta"
+          :model-value="
+            edited.mirostat_eta ?? settingsStore.chatOptions.mirostat_eta ?? 0.1
+          "
+          @update:model-value="edited = { ...edited, mirostat_eta: $event }"
+          :min="0.01"
+          :max="1"
+          :step="0.01"
         />
         <SettingsSlider
           label="Repeat Penalty"
@@ -220,6 +248,7 @@ import { useModelStore } from "../../stores/models";
 import { useAppOrchestration } from "../../composables/useAppOrchestration";
 import { useModelDefaults } from "../../composables/useModelDefaults";
 import SettingsSlider from "../settings/SettingsSlider.vue";
+import MirostatSelector from "../shared/MirostatSelector.vue";
 import type { Model } from "../../types/models";
 import type { ChatOptions } from "../../types/settings";
 
@@ -238,6 +267,14 @@ const { applyModelDefaults, saveAsModelDefault, resetModelDefaults } =
 
 const loading = ref(true);
 const edited = ref<Partial<ChatOptions>>({});
+
+const effectiveMirostat = computed(
+  () => edited.value.mirostat ?? settingsStore.chatOptions.mirostat ?? 0,
+);
+
+function updateMirostat(value: 0 | 1 | 2) {
+  edited.value = { ...edited.value, mirostat: value };
+}
 const saved = ref(false);
 const saveError = ref(false);
 const editingTags = ref(false);

--- a/src/components/shared/MirostatSelector.vue
+++ b/src/components/shared/MirostatSelector.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: 0 | 1 | 2;
+  compact?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: 0 | 1 | 2): void;
+}>();
+
+const options = [
+  { value: 0 as const, label: "Off" },
+  { value: 1 as const, label: "Mirostat 1" },
+  { value: 2 as const, label: "Mirostat 2" },
+];
+</script>
+
+<template>
+  <div class="flex flex-col" :class="compact ? 'gap-1.5' : 'gap-2'">
+    <span
+      class="font-medium text-[var(--text-muted)]"
+      :class="compact ? 'text-[11px]' : 'text-[12px]'"
+      >Sampling Mode</span
+    >
+    <div class="flex rounded-lg overflow-hidden border border-[var(--border)]">
+      <button
+        v-for="opt in options"
+        :key="opt.value"
+        @click="emit('update:modelValue', opt.value)"
+        class="flex-1 font-medium transition-colors cursor-pointer"
+        :class="[
+          compact ? 'py-1 text-[10px]' : 'py-1.5 text-[11px]',
+          modelValue === opt.value
+            ? 'bg-[var(--accent)] text-white'
+            : 'bg-[var(--bg-input)] text-[var(--text-muted)] hover:text-[var(--text)] hover:bg-[var(--bg-hover)]',
+        ]"
+      >
+        {{ opt.label }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -72,6 +72,9 @@ const DEFAULT_CHAT_OPTIONS: SettingsState["chatOptions"] = {
   num_ctx: 4096,
   repeat_penalty: 1.1,
   repeat_last_n: 64,
+  mirostat: 0,
+  mirostat_tau: 5,
+  mirostat_eta: 0.1,
 };
 
 const getInitialState = (): SettingsState => ({

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -9,6 +9,9 @@ export interface ChatOptions {
   repeat_last_n?: number;
   seed?: number;
   stop?: string[];
+  mirostat?: 0 | 1 | 2;
+  mirostat_tau?: number;
+  mirostat_eta?: number;
 }
 
 export type PresetOptions = Required<
@@ -21,7 +24,11 @@ export type PresetOptions = Required<
     | "repeat_penalty"
     | "repeat_last_n"
   >
->;
+> & {
+  mirostat?: 0 | 1 | 2;
+  mirostat_tau?: number;
+  mirostat_eta?: number;
+};
 
 export interface Preset {
   id: string;

--- a/src/views/SettingsPage.advanced.spec.ts
+++ b/src/views/SettingsPage.advanced.spec.ts
@@ -145,3 +145,83 @@ describe("SettingsPage — Advanced tab (S-06 stop sequences)", () => {
     expect(store.chatOptions.stop).toBeUndefined();
   });
 });
+
+describe("SettingsPage — Engine Presets mirostat controls (S-08)", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue([]);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // The Presets editor (with MirostatSelector) lives in the 'models' tab ("Engine")
+  async function mountPageOnEngine() {
+    const wrapper = mountPage();
+    const vm = wrapper.vm as unknown as { activeTab: string };
+    vm.activeTab = "models";
+    await wrapper.vm.$nextTick();
+    return wrapper;
+  }
+
+  it("renders Sampling Mode selector with Off/Mirostat1/Mirostat2 buttons in preset editor", async () => {
+    const wrapper = await mountPageOnEngine();
+
+    const buttons = wrapper
+      .findAll("button")
+      .filter((b) => ["Off", "Mirostat 1", "Mirostat 2"].includes(b.text()));
+    expect(buttons).toHaveLength(3);
+  });
+
+  it("updateLocalMirostat(1) sets localMirostat to 1", async () => {
+    const wrapper = await mountPageOnEngine();
+    const vm = wrapper.vm as unknown as {
+      localMirostat: number;
+      updateLocalMirostat: (v: 0 | 1 | 2) => void;
+    };
+
+    vm.updateLocalMirostat(1);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.localMirostat).toBe(1);
+  });
+
+  it("updateLocalMirostat(2) sets localMirostat to 2", async () => {
+    const wrapper = await mountPageOnEngine();
+    const vm = wrapper.vm as unknown as {
+      localMirostat: number;
+      updateLocalMirostat: (v: 0 | 1 | 2) => void;
+    };
+
+    vm.updateLocalMirostat(2);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.localMirostat).toBe(2);
+  });
+
+  it("updateLocalMirostat(0) resets localMirostat to 0", async () => {
+    const wrapper = await mountPageOnEngine();
+    const vm = wrapper.vm as unknown as {
+      localMirostat: number;
+      updateLocalMirostat: (v: 0 | 1 | 2) => void;
+    };
+
+    vm.updateLocalMirostat(2);
+    await wrapper.vm.$nextTick();
+    vm.updateLocalMirostat(0);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.localMirostat).toBe(0);
+  });
+
+  it("localMirostat defaults to 0 when preset has no mirostat field", async () => {
+    const wrapper = await mountPageOnEngine();
+    const vm = wrapper.vm as unknown as { localMirostat: number };
+    expect(vm.localMirostat).toBe(0);
+  });
+});

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -380,6 +380,12 @@
               <div
                 class="flex flex-col gap-4 pt-3 border-t border-[var(--border-subtle)]"
               >
+                <MirostatSelector
+                  :model-value="localMirostat"
+                  compact
+                  @update:model-value="updateLocalMirostat"
+                />
+
                 <SettingsSlider
                   label="Temperature"
                   :model-value="localOptions.temperature"
@@ -390,6 +396,7 @@
                   compact
                 />
                 <SettingsSlider
+                  v-if="localMirostat === 0"
                   label="Top P"
                   :model-value="localOptions.top_p"
                   @update:model-value="updateLocalOption('top_p', $event)"
@@ -399,12 +406,37 @@
                   compact
                 />
                 <SettingsSlider
+                  v-if="localMirostat === 0"
                   label="Top K"
                   :model-value="localOptions.top_k"
                   @update:model-value="updateLocalOption('top_k', $event)"
                   :min="0"
                   :max="100"
                   :step="1"
+                  compact
+                />
+                <SettingsSlider
+                  v-if="localMirostat !== 0"
+                  label="Mirostat Tau"
+                  :model-value="localOptions.mirostat_tau ?? 5"
+                  @update:model-value="
+                    updateLocalOption('mirostat_tau', $event)
+                  "
+                  :min="0.1"
+                  :max="10"
+                  :step="0.1"
+                  compact
+                />
+                <SettingsSlider
+                  v-if="localMirostat !== 0"
+                  label="Mirostat Eta"
+                  :model-value="localOptions.mirostat_eta ?? 0.1"
+                  @update:model-value="
+                    updateLocalOption('mirostat_eta', $event)
+                  "
+                  :min="0.01"
+                  :max="1"
+                  :step="0.01"
                   compact
                 />
                 <SettingsSlider
@@ -692,6 +724,7 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import StopSequencesInput from "../components/settings/StopSequencesInput.vue";
+import MirostatSelector from "../components/shared/MirostatSelector.vue";
 import { useSettingsStore } from "../stores/settings";
 import type { PresetOptions } from "../types/settings";
 import { useModelStore } from "../stores/models";
@@ -720,6 +753,9 @@ const localOptions = ref<PresetOptions>(
         num_ctx: settingsStore.chatOptions.num_ctx,
         repeat_penalty: settingsStore.chatOptions.repeat_penalty,
         repeat_last_n: settingsStore.chatOptions.repeat_last_n,
+        mirostat: settingsStore.chatOptions.mirostat,
+        mirostat_tau: settingsStore.chatOptions.mirostat_tau,
+        mirostat_eta: settingsStore.chatOptions.mirostat_eta,
       }
     );
   })(),
@@ -734,6 +770,13 @@ function selectPreviewPreset(id: string) {
 function updateLocalOption(key: keyof PresetOptions, value: number) {
   previewPresetId.value = "";
   localOptions.value = { ...localOptions.value, [key]: value };
+}
+
+const localMirostat = computed(() => localOptions.value.mirostat ?? 0);
+
+function updateLocalMirostat(value: 0 | 1 | 2) {
+  previewPresetId.value = "";
+  localOptions.value = { ...localOptions.value, mirostat: value };
 }
 
 const savingPreset = ref(false);


### PR DESCRIPTION
## Summary
- Adds Mirostat Off/v1/v2 mode selector to **Advanced Chat Options** panel (per-request)
- Adds Mirostat selector to **Engine Presets** editor in Settings (saved presets)
- Adds Mirostat selector to **Default Generation Settings** on the model details page
- Tau (default 5.0) and Eta (default 0.1) sliders appear when Mirostat is active; Top-P and Top-K are hidden in all three panels
- Parameters forwarded to Ollama as \`options.mirostat\`, \`options.mirostat_tau\`, \`options.mirostat_eta\`
- Per-model defaults and saved presets correctly persist mirostat settings

Closes #21

## Test plan
- [x] Toggle through Off / Mirostat 1 / Mirostat 2 in the Advanced Options panel — selector highlights active mode, Top P/K hide, Tau/Eta appear
- [x] Same in Settings → Engine Presets editor — selector works, save as preset captures mirostat
- [x] Same in Models → model details → Default Generation Settings — save persists mirostat
- [x] Send a chat message with Mirostat 2, tau=4.0, eta=0.05 — verify Ollama receives the parameters
- [x] Apply a saved preset — mirostat mode restored correctly
- [x] \`pnpm test\` passes (495 tests); \`cargo test\` passes