### PR TITLE
feat(S-07): seed control for reproducible generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- S-07: Seed control — fixed-seed input in Advanced Options and Settings for reproducible generation; active seed shown in message performance metadata (#20)
 - S-08: Mirostat v1/v2 sampling controls in Advanced Chat Options — Mirostat mode selector (Off/Mirostat 1/Mirostat 2) with tau (default 5.0) and eta (default 0.1) sliders; top-p/top-k hidden when Mirostat is active
 - S-06: Custom stop sequences — Settings → Advanced tab with a tag-input for up to 4 stop tokens (e.g. `###`, `<END>`). Sequences are sent as `options.stop` in every Ollama chat request; empty list omits the field entirely. Setting key allowlist added to the backend `set_setting` command.
 - MO-06: Custom model creation from Modelfile — create and edit Ollama models directly in the app with a CodeMirror editor, streaming progress, background creation, desktop notifications, and mid-stream cancellation (#22)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -439,7 +439,7 @@ Ollama API ──(NDJSON stream)──► Rust (reqwest bytes_stream)
 | `chat:thinking-start` | Rust → Vue | `{ conversation_id }` | Opening `<think>` tag detected |
 | `chat:thinking-token` | Rust → Vue | `{ conversation_id, content }` | Token inside a `<think>` block |
 | `chat:thinking-end` | Rust → Vue | `{ conversation_id }` | Closing `</think>` tag detected |
-| `chat:done` | Rust → Vue | `{ conversation_id, total_tokens?, duration_ms?, tokens_per_sec? }` | Generation complete, message persisted |
+| `chat:done` | Rust → Vue | `{ conversation_id, total_tokens?, duration_ms?, tokens_per_sec?, seed? }` | Generation complete, message persisted; `seed` present only when a fixed seed was used |
 | `chat:error` | Rust → Vue | `{ conversation_id, error }` | Stream or generation error |
 | `chat:tool-call` | Rust → Vue | `{ conversation_id, tool_name, arguments }` | LLM requested a tool call (web search) |
 | `chat:tool-result` | Rust → Vue | `{ conversation_id, tool_name, result }` | Tool call result returned to LLM |

--- a/src-tauri/src/commands/chat.tests.rs
+++ b/src-tauri/src/commands/chat.tests.rs
@@ -42,6 +42,7 @@ fn test_export_conversation_to_path_red() {
             load_duration_ms: None,
             prompt_eval_duration_ms: None,
             eval_duration_ms: None,
+            seed: None,
         },
     )
     .unwrap();

--- a/src-tauri/src/db/conversations.rs
+++ b/src-tauri/src/db/conversations.rs
@@ -208,6 +208,7 @@ pub fn update_system_prompt(
                 load_duration_ms: None,
                 prompt_eval_duration_ms: None,
                 eval_duration_ms: None,
+                seed: None,
             },
         )?;
     }

--- a/src-tauri/src/db/messages.rs
+++ b/src-tauri/src/db/messages.rs
@@ -25,6 +25,7 @@ pub struct Message {
     pub load_duration_ms: Option<i64>,
     pub prompt_eval_duration_ms: Option<i64>,
     pub eval_duration_ms: Option<i64>,
+    pub seed: Option<i64>,
     pub created_at: String,
 }
 
@@ -75,6 +76,7 @@ pub struct NewMessage {
     pub load_duration_ms: Option<i64>,
     pub prompt_eval_duration_ms: Option<i64>,
     pub eval_duration_ms: Option<i64>,
+    pub seed: Option<i64>,
 }
 
 fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<Message> {
@@ -96,7 +98,8 @@ fn row_to_message(row: &rusqlite::Row<'_>) -> rusqlite::Result<Message> {
         load_duration_ms: row.get(11)?,
         prompt_eval_duration_ms: row.get(12)?,
         eval_duration_ms: row.get(13)?,
-        created_at: row.get(14)?,
+        seed: row.get(14)?,
+        created_at: row.get(15)?,
     })
 }
 
@@ -109,9 +112,9 @@ pub fn list_for_conversation(
 ) -> Result<Vec<Message>, AppError> {
     let mut stmt = conn.prepare(
         "SELECT id, conversation_id, role, content, images_json, files_json,
-                tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec, 
-                total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms, 
-                created_at
+                tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec,
+                total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms,
+                seed, created_at
          FROM messages
          WHERE conversation_id = ?1
          ORDER BY created_at ASC",
@@ -132,9 +135,10 @@ pub fn create(conn: &Connection, new: NewMessage) -> Result<Message, AppError> {
     conn.execute(
         "INSERT INTO messages
              (id, conversation_id, role, content, images_json, files_json,
-              tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec, 
-              total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms, created_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+              tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec,
+              total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms,
+              seed, created_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)",
         params![
             id,
             new.conversation_id,
@@ -150,15 +154,16 @@ pub fn create(conn: &Connection, new: NewMessage) -> Result<Message, AppError> {
             new.load_duration_ms,
             new.prompt_eval_duration_ms,
             new.eval_duration_ms,
+            new.seed,
             now,
         ],
     )?;
 
     conn.query_row(
         "SELECT id, conversation_id, role, content, images_json, files_json,
-                tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec, 
-                total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms, 
-                created_at
+                tokens_used, generation_time_ms, prompt_tokens, tokens_per_sec,
+                total_duration_ms, load_duration_ms, prompt_eval_duration_ms, eval_duration_ms,
+                seed, created_at
          FROM messages WHERE id = ?1",
         params![id],
         row_to_message,
@@ -234,6 +239,7 @@ mod tests {
                 load_duration_ms: None,
                 prompt_eval_duration_ms: None,
                 eval_duration_ms: None,
+                seed: None,
             },
         )
         .unwrap();
@@ -254,6 +260,7 @@ mod tests {
                 load_duration_ms: Some(10),
                 prompt_eval_duration_ms: Some(40),
                 eval_duration_ms: Some(250),
+                seed: None,
             },
         )
         .unwrap();
@@ -285,6 +292,7 @@ mod tests {
                 load_duration_ms: None,
                 prompt_eval_duration_ms: None,
                 eval_duration_ms: None,
+                seed: None,
             },
         )
         .unwrap();

--- a/src-tauri/src/db/migrations.rs
+++ b/src-tauri/src/db/migrations.rs
@@ -31,6 +31,11 @@ const MIGRATIONS: &[Migration] = &[
         description: "model_user_data table",
         sql: include_str!("sql/003_model_user_data.sql"),
     },
+    Migration {
+        version: 12,
+        description: "message seed column",
+        sql: include_str!("sql/004_message_seed.sql"),
+    },
 ];
 
 // ── Runner ─────────────────────────────────────────────────────────────────────

--- a/src-tauri/src/db/repo.rs
+++ b/src-tauri/src/db/repo.rs
@@ -55,6 +55,7 @@ impl ConversationRepository {
                 load_duration_ms: None,
                 prompt_eval_duration_ms: None,
                 eval_duration_ms: None,
+                seed: None,
             };
 
             messages::create(&tx, new_user_msg)?;
@@ -99,6 +100,7 @@ impl ConversationRepository {
                     load_duration_ms: metrics.load_duration_ms,
                     prompt_eval_duration_ms: metrics.prompt_eval_duration_ms,
                     eval_duration_ms: metrics.eval_duration_ms,
+                    seed: metrics.seed,
                 },
             )?;
             Ok(())
@@ -118,4 +120,5 @@ pub struct AssistantMetrics {
     pub load_duration_ms: Option<i64>,
     pub prompt_eval_duration_ms: Option<i64>,
     pub eval_duration_ms: Option<i64>,
+    pub seed: Option<i64>,
 }

--- a/src-tauri/src/db/sql/004_message_seed.sql
+++ b/src-tauri/src/db/sql/004_message_seed.sql
@@ -1,0 +1,1 @@
+ALTER TABLE messages ADD COLUMN seed INTEGER;

--- a/src-tauri/src/services/chat.rs
+++ b/src-tauri/src/services/chat.rs
@@ -134,6 +134,7 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                     load_duration_ms: None,
                     prompt_eval_duration_ms: None,
                     eval_duration_ms: None,
+                    seed: None,
                 },
             )?;
 
@@ -317,6 +318,7 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                         load_duration_ms: m.load_duration_ms,
                         prompt_eval_duration_ms: m.prompt_eval_duration_ms,
                         eval_duration_ms: m.eval_duration_ms,
+                        seed: m.seed,
                     },
                 )
             })
@@ -531,6 +533,7 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                         load_duration_ms: msg.load_duration_ms,
                         prompt_eval_duration_ms: msg.prompt_eval_duration_ms,
                         eval_duration_ms: msg.eval_duration_ms,
+                        seed: msg.seed,
                     },
                 )?;
             }
@@ -712,6 +715,8 @@ impl<'a, R: Runtime> ChatService<'a, R> {
             }
         }
 
+        metrics.seed = options.as_ref().and_then(|o| o.seed);
+
         // Emit final done event after all agent turns are complete
         let _ = self.app.emit(
             "chat:done",
@@ -725,6 +730,7 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                 "load_duration_ms": metrics.load_duration_ms,
                 "prompt_eval_duration_ms": metrics.prompt_eval_duration_ms,
                 "eval_duration_ms": metrics.eval_duration_ms,
+                "seed": metrics.seed,
             }),
         );
 

--- a/src-tauri/tests/chat_test.rs
+++ b/src-tauri/tests/chat_test.rs
@@ -416,6 +416,7 @@ async fn test_create_conversation_and_get_messages() {
             load_duration_ms: None,
             prompt_eval_duration_ms: None,
             eval_duration_ms: None,
+            seed: None,
         },
     )
     .unwrap();
@@ -436,6 +437,7 @@ async fn test_create_conversation_and_get_messages() {
             load_duration_ms: None,
             prompt_eval_duration_ms: None,
             eval_duration_ms: None,
+            seed: None,
         },
     )
     .unwrap();

--- a/src/components/chat/MessageBubble.vue
+++ b/src/components/chat/MessageBubble.vue
@@ -416,6 +416,7 @@ const settingsStore = useSettingsStore();
       :input-tokens="message.prompt_tokens || 0"
       :generation-time-ms="message.generation_time_ms || 0"
       :message-key="messageId"
+      :seed="message.seed"
     />
   </div>
 </template>

--- a/src/components/chat/StatsBlock.test.ts
+++ b/src/components/chat/StatsBlock.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+
+vi.mock("../../composables/useCollapsibleState", () => ({
+  useCollapsibleState: vi.fn(() => ({
+    isOpen: { value: false },
+    toggle: vi.fn(),
+    setOpen: vi.fn(),
+  })),
+}));
+
+const { default: StatsBlock } = await import("./StatsBlock.vue");
+
+const baseProps = {
+  metrics: {
+    total_duration_ms: 1410,
+    load_duration_ms: 10,
+    prompt_eval_duration_ms: 200,
+    eval_duration_ms: 1200,
+  },
+  tokensPerSec: 23.4,
+  outputTokens: 312,
+  inputTokens: 88,
+  generationTimeMs: 1410,
+};
+
+describe("StatsBlock seed badge", () => {
+  it("shows no seed badge when seed is undefined", () => {
+    const wrapper = mount(StatsBlock, { props: { ...baseProps } });
+    expect(wrapper.find("[data-testid='seed-badge']").exists()).toBe(false);
+  });
+
+  it("shows accent seed badge when seed is set", () => {
+    const wrapper = mount(StatsBlock, {
+      props: { ...baseProps, seed: 42 },
+    });
+    expect(wrapper.find("[data-testid='seed-badge']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='seed-badge']").text()).toContain("42");
+  });
+
+  it("renders seed row in DOM when seed is set", () => {
+    const wrapper = mount(StatsBlock, {
+      props: { ...baseProps, seed: 42 },
+    });
+    expect(wrapper.find("[data-testid='seed-row']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='seed-row']").text()).toContain("42");
+  });
+
+  it("shows seed badge and row when seed is 0", () => {
+    const wrapper = mount(StatsBlock, {
+      props: { ...baseProps, seed: 0 },
+    });
+    expect(wrapper.find("[data-testid='seed-badge']").exists()).toBe(true);
+    expect(wrapper.find("[data-testid='seed-row']").exists()).toBe(true);
+  });
+});

--- a/src/components/chat/StatsBlock.vue
+++ b/src/components/chat/StatsBlock.vue
@@ -73,6 +73,28 @@
           </span>
         </CustomTooltip>
 
+        <!-- Seed (only when a fixed seed was used) -->
+        <CustomTooltip
+          v-if="seed !== undefined"
+          text="Fixed seed — generation is reproducible"
+        >
+          <span class="stat-badge stat-badge--seed" data-testid="seed-badge">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+            >
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+            </svg>
+            {{ seed }}
+          </span>
+        </CustomTooltip>
+
         <span class="more-label">
           {{ isOpen ? "Hide" : "More" }}
           <svg
@@ -143,6 +165,10 @@
                 <td>Eval Rate (Generation)</td>
                 <td>{{ (tokensPerSec || 0).toFixed(1) }} tokens/s</td>
               </tr>
+              <tr v-if="seed !== undefined" data-testid="seed-row">
+                <td>Seed</td>
+                <td>{{ seed }}</td>
+              </tr>
             </tbody>
           </table>
         </div>
@@ -167,6 +193,7 @@ const props = defineProps<{
   inputTokens: number;
   generationTimeMs: number;
   messageKey?: string;
+  seed?: number;
 }>();
 
 // suffix: 'stats' isolates this cache key from ThinkBlock (bare key) and SearchBlock ('search')
@@ -307,5 +334,12 @@ function toggle(event: MouseEvent) {
 
 .full-stats-table tr:not(:last-child) {
   border-bottom: 1px solid var(--border-subtle);
+}
+
+.stat-badge--seed {
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+  background: color-mix(in srgb, var(--accent) 8%, var(--bg-active));
+  font-weight: 600;
 }
 </style>

--- a/src/components/chat/input/AdvancedChatOptions.spec.ts
+++ b/src/components/chat/input/AdvancedChatOptions.spec.ts
@@ -1,17 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, flushPromises } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 
+const mockInvoke = vi.fn().mockResolvedValue(undefined);
 vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn().mockResolvedValue(undefined),
+  invoke: (cmd: string, args: unknown) => mockInvoke(cmd, args),
 }));
 
 import AdvancedChatOptions from "./AdvancedChatOptions.vue";
 import type { ChatOptions } from "../../../types/settings";
 
-function mountComponent(modelValue: Partial<ChatOptions> = {}, presetId = "") {
+function mountComponent(
+  modelValue: Partial<ChatOptions> = {},
+  presetId = "",
+  model?: string,
+) {
   return mount(AdvancedChatOptions, {
-    props: { modelValue, presetId },
+    props: { modelValue, presetId, ...(model ? { model } : {}) },
     global: { plugins: [createPinia()] },
   });
 }
@@ -84,5 +89,85 @@ describe("AdvancedChatOptions — Mirostat controls", () => {
     expect(html).toContain("Top K");
     expect(html).not.toContain("Mirostat Tau");
     expect(html).not.toContain("Mirostat Eta");
+  });
+});
+
+describe("AdvancedChatOptions — Seed control", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it("emits update:modelValue with seed=42 when input changes to '42'", async () => {
+    const wrapper = mountComponent({});
+    const input = wrapper.find('input[type="number"]');
+    (input.element as HTMLInputElement).value = "42";
+    await input.trigger("change");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect((emitted![0][0] as Partial<ChatOptions>).seed).toBe(42);
+  });
+
+  it("emits update:modelValue with seed=undefined when input changes to ''", async () => {
+    const wrapper = mountComponent({ seed: 7 });
+    const input = wrapper.find('input[type="number"]');
+    (input.element as HTMLInputElement).value = "";
+    await input.trigger("change");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect((emitted![0][0] as Partial<ChatOptions>).seed).toBeUndefined();
+  });
+
+  it("emits update:presetId with '' when seed is changed", async () => {
+    const wrapper = mountComponent({}, "my-preset");
+    const input = wrapper.find('input[type="number"]');
+    (input.element as HTMLInputElement).value = "99";
+    await input.trigger("change");
+    const emitted = wrapper.emitted("update:presetId");
+    expect(emitted).toBeTruthy();
+    expect(emitted![0][0]).toBe("");
+  });
+
+  it("reset button is visible when seed is set and calls updateSeed('')", async () => {
+    const wrapper = mountComponent({ seed: 7 });
+    const resetBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Reset");
+    expect(resetBtn).toBeDefined();
+    await resetBtn!.trigger("click");
+    const emitted = wrapper.emitted("update:modelValue");
+    expect(emitted).toBeTruthy();
+    expect((emitted![0][0] as Partial<ChatOptions>).seed).toBeUndefined();
+  });
+
+  it("reset button is not rendered when seed is undefined", () => {
+    const wrapper = mountComponent({});
+    const resetButtons = wrapper
+      .findAll("button")
+      .filter((b) => b.text() === "Reset");
+    expect(resetButtons).toHaveLength(0);
+  });
+
+  it("'Set as default' button only renders when model prop is provided", () => {
+    const withoutModel = mountComponent({});
+    const withModel = mountComponent({}, "", "llama3:latest");
+    const hasDefault = (w: ReturnType<typeof mountComponent>) =>
+      w.findAll("button").some((b) => b.text().includes("Set as default"));
+    expect(hasDefault(withoutModel)).toBe(false);
+    expect(hasDefault(withModel)).toBe(true);
+  });
+
+  it("'Set as default' button calls set_model_defaults invoke on click", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const wrapper = mountComponent({ temperature: 0.5 }, "", "llama3:latest");
+    const defaultBtn = wrapper
+      .findAll("button")
+      .find((b) => b.text().includes("Set as default"))!;
+    await defaultBtn.trigger("click");
+    await flushPromises();
+    expect(mockInvoke).toHaveBeenCalledWith(
+      "set_model_defaults",
+      expect.objectContaining({ modelName: "llama3:latest" }),
+    );
   });
 });

--- a/src/components/chat/input/AdvancedChatOptions.vue
+++ b/src/components/chat/input/AdvancedChatOptions.vue
@@ -255,6 +255,40 @@
         :step="8"
         compact
       />
+
+      <!-- Seed -->
+      <div
+        class="flex flex-col gap-2 pt-1 border-t border-[var(--border-subtle)]"
+      >
+        <div>
+          <p class="text-[11px] font-bold text-[var(--text)]">Seed</p>
+          <p class="text-[10px] text-[var(--text-dim)] mt-0.5">
+            Fixed integer for reproducible generation. Leave empty for random
+            output.
+          </p>
+        </div>
+        <div class="flex items-center gap-2">
+          <input
+            type="number"
+            :value="props.modelValue.seed ?? ''"
+            @change="updateSeed(($event.target as HTMLInputElement).value)"
+            placeholder="empty = random"
+            class="flex-1 bg-[var(--bg-input)] border text-[var(--text)] rounded-lg px-2 py-1 text-[11px] outline-none transition-colors"
+            :class="
+              props.modelValue.seed !== undefined
+                ? 'border-[var(--accent)] text-[var(--accent)]'
+                : 'border-[var(--border)] focus:border-[var(--accent)]'
+            "
+          />
+          <button
+            v-if="props.modelValue.seed !== undefined"
+            @click="updateSeed('')"
+            class="text-[10px] px-2 py-1 rounded-lg border border-[var(--border)] text-[var(--text-dim)] hover:text-[var(--text)] hover:border-[var(--border-strong)] transition-colors cursor-pointer whitespace-nowrap"
+          >
+            Reset
+          </button>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -337,6 +371,15 @@ function updateOption(key: keyof ChatOptions, value: number) {
 
 function updateMirostat(value: 0 | 1 | 2) {
   emit("update:modelValue", { ...props.modelValue, mirostat: value });
+  emit("update:presetId", "");
+}
+
+function updateSeed(raw: string) {
+  const parsed = raw === "" ? undefined : Number.parseInt(raw, 10);
+  emit("update:modelValue", {
+    ...props.modelValue,
+    seed: Number.isNaN(parsed) ? undefined : parsed,
+  });
   emit("update:presetId", "");
 }
 

--- a/src/components/models/LocalModelDetails.vue
+++ b/src/components/models/LocalModelDetails.vue
@@ -212,6 +212,40 @@
           :step="512"
         />
 
+        <!-- Seed -->
+        <div class="flex flex-col gap-2">
+          <div>
+            <p class="text-[13px] font-semibold text-[var(--text)]">Seed</p>
+            <p class="text-[11.5px] text-[var(--text-dim)] mt-0.5">
+              Fixed integer for reproducible generation. Leave empty for random
+              output.
+            </p>
+          </div>
+          <div class="flex items-center gap-2">
+            <input
+              type="number"
+              :value="edited.seed ?? ''"
+              @change="
+                updateEditedSeed(($event.target as HTMLInputElement).value)
+              "
+              placeholder="empty = random"
+              class="flex-1 bg-[var(--bg-input)] border text-[var(--text)] rounded-lg px-2 py-1.5 text-[12px] outline-none transition-colors"
+              :class="
+                edited.seed !== undefined
+                  ? 'border-[var(--accent)] text-[var(--accent)]'
+                  : 'border border-[var(--border)] focus:border-[var(--accent)]'
+              "
+            />
+            <button
+              v-if="edited.seed !== undefined"
+              @click="edited = { ...edited, seed: undefined }"
+              class="text-[11px] px-2.5 py-1.5 rounded-lg border border-[var(--border)] text-[var(--text-dim)] hover:text-[var(--text)] hover:border-[var(--border-strong)] transition-colors cursor-pointer whitespace-nowrap"
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+
         <div
           class="flex items-center justify-between pt-2 border-t border-[var(--border-subtle)]"
         >
@@ -311,6 +345,14 @@ onMounted(async () => {
     loading.value = false;
   }
 });
+
+function updateEditedSeed(raw: string) {
+  const n = Number.parseInt(raw, 10);
+  edited.value = {
+    ...edited.value,
+    seed: raw === "" || Number.isNaN(n) ? undefined : n,
+  };
+}
 
 async function resetToGlobal() {
   await resetModelDefaults(props.model.name);

--- a/src/composables/useStreamingEvents.ts
+++ b/src/composables/useStreamingEvents.ts
@@ -84,6 +84,7 @@ export function useStreamingEvents() {
           payload.load_duration_ms,
           payload.prompt_eval_duration_ms,
           payload.eval_duration_ms,
+          payload.seed,
         );
         chatStore.streaming.isStreaming = false;
         chatStore.streaming.tokensPerSec = payload.tokens_per_sec;

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useChatStore } from "./chat";
+import type { LinkedContext } from "../types/chat";
 
 const mockInvoke = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({
@@ -103,6 +104,205 @@ describe("useChatStore", () => {
     expect(content).toContain("<think>");
     expect(content).toContain("internal reasoning");
     expect(content).toContain("Answer");
+  });
+
+  it("propagates seed onto the pushed message", () => {
+    const store = useChatStore();
+    store.messages["conv-1"] = [];
+    store.streaming.buffer = "reply";
+
+    store.finalizeStreamedMessage(
+      "conv-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      42,
+    );
+
+    expect(store.messages["conv-1"][0].seed).toBe(42);
+  });
+
+  it("leaves seed undefined when not provided", () => {
+    const store = useChatStore();
+    store.messages["conv-2"] = [];
+    store.streaming.buffer = "reply";
+
+    store.finalizeStreamedMessage("conv-2");
+
+    expect(store.messages["conv-2"][0].seed).toBeUndefined();
+  });
+
+  it("treats JSON null seed (Rust None) as undefined in finalizeStreamedMessage", () => {
+    const store = useChatStore();
+    store.messages["conv-3"] = [];
+    store.streaming.buffer = "reply";
+
+    store.finalizeStreamedMessage(
+      "conv-3",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      null as unknown as undefined,
+    );
+
+    expect(store.messages["conv-3"][0].seed).toBeUndefined();
+  });
+
+  it("treats JSON null seed (Rust None) as undefined in loadConversation", async () => {
+    const store = useChatStore();
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === "get_messages") {
+        return [
+          {
+            id: "msg-null-seed",
+            conversation_id: "conv-null",
+            role: "assistant",
+            content: "Hello",
+            images_json: "[]",
+            files_json: "[]",
+            tokens_used: 5,
+            generation_time_ms: 100,
+            seed: null,
+            created_at: "2026-01-01T00:00:00Z",
+          },
+        ];
+      }
+      if (cmd === "get_folder_contexts") return [];
+      return null;
+    });
+
+    await store.loadConversation("conv-null");
+
+    expect(store.messages["conv-null"][0].seed).toBeUndefined();
+  });
+
+  // --- addFolderContext ---
+
+  it("addFolderContext adds a context to folderContexts[conversationId]", () => {
+    const store = useChatStore();
+    const ctx: LinkedContext = {
+      id: "ctx-1",
+      name: "folder",
+      path: "/tmp/folder",
+      content: "...",
+      tokens: 100,
+    };
+    store.addFolderContext("conv-1", ctx);
+    expect(store.folderContexts["conv-1"]).toHaveLength(1);
+    expect(store.folderContexts["conv-1"][0].id).toBe("ctx-1");
+  });
+
+  it("addFolderContext skips duplicate entries by path", () => {
+    const store = useChatStore();
+    const ctx: LinkedContext = {
+      id: "ctx-1",
+      name: "folder",
+      path: "/tmp/folder",
+      content: "...",
+      tokens: 100,
+    };
+    const ctxDup: LinkedContext = {
+      id: "ctx-2",
+      name: "folder-dup",
+      path: "/tmp/folder",
+      content: "other",
+      tokens: 50,
+    };
+    store.addFolderContext("conv-1", ctx);
+    store.addFolderContext("conv-1", ctxDup);
+    expect(store.folderContexts["conv-1"]).toHaveLength(1);
+    expect(store.folderContexts["conv-1"][0].id).toBe("ctx-1");
+  });
+
+  // --- removeFolderContext ---
+
+  it("removeFolderContext removes a context by contextId", () => {
+    const store = useChatStore();
+    const ctx: LinkedContext = {
+      id: "ctx-1",
+      name: "folder",
+      path: "/tmp/folder",
+      content: "...",
+      tokens: 100,
+    };
+    store.addFolderContext("conv-1", ctx);
+    store.removeFolderContext("conv-1", "ctx-1");
+    expect(store.folderContexts["conv-1"]).toHaveLength(0);
+  });
+
+  it("removeFolderContext is a no-op when conversationId not in folderContexts", () => {
+    const store = useChatStore();
+    expect(() =>
+      store.removeFolderContext("nonexistent", "ctx-1"),
+    ).not.toThrow();
+    expect(store.folderContexts["nonexistent"]).toBeUndefined();
+  });
+
+  // --- clearFolderContext ---
+
+  it("clearFolderContext deletes folderContexts[conversationId] entirely", () => {
+    const store = useChatStore();
+    const ctx: LinkedContext = {
+      id: "ctx-1",
+      name: "folder",
+      path: "/tmp/folder",
+      content: "...",
+      tokens: 100,
+    };
+    store.addFolderContext("conv-1", ctx);
+    expect(store.folderContexts["conv-1"]).toBeDefined();
+    store.clearFolderContext("conv-1");
+    expect(store.folderContexts["conv-1"]).toBeUndefined();
+  });
+
+  // --- compactConversation ---
+
+  it("compactConversation calls invoke('compact_conversation') and returns the new conversation ID", async () => {
+    const store = useChatStore();
+    mockInvoke.mockImplementation(async (cmd, args) => {
+      if (cmd === "compact_conversation") return "new-conv-id";
+      if (cmd === "list_conversations") return [];
+      if (cmd === "get_folder_contexts") return [];
+      return null;
+    });
+
+    const result = await store.compactConversation(
+      "old-conv-id",
+      "llama3:latest",
+      "Compacted",
+    );
+    expect(result).toBe("new-conv-id");
+    expect(mockInvoke).toHaveBeenCalledWith("compact_conversation", {
+      conversationId: "old-conv-id",
+      model: "llama3:latest",
+      title: "Compacted",
+    });
+  });
+
+  it("compactConversation calls loadConversations(true) after compacting", async () => {
+    const store = useChatStore();
+    mockInvoke.mockImplementation(async (cmd) => {
+      if (cmd === "compact_conversation") return "new-conv-id";
+      if (cmd === "list_conversations") return [];
+      if (cmd === "get_folder_contexts") return [];
+      return null;
+    });
+
+    await store.compactConversation("old-conv-id", "llama3:latest");
+    expect(mockInvoke).toHaveBeenCalledWith("list_conversations", {
+      limit: 20,
+      offset: 0,
+    });
   });
 
   it("loadConversations handles pagination and appends to existing list", async () => {

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -156,6 +156,7 @@ export const useChatStore = defineStore("chat", {
       loadDurationMs?: number,
       promptEvalDurationMs?: number,
       evalDurationMs?: number,
+      seed?: number,
     ) {
       if (!this.messages[conversationId]) {
         this.messages[conversationId] = [];
@@ -177,6 +178,7 @@ export const useChatStore = defineStore("chat", {
         load_duration_ms: loadDurationMs ?? 0,
         prompt_eval_duration_ms: promptEvalDurationMs ?? 0,
         eval_duration_ms: evalDurationMs ?? 0,
+        seed: seed ?? undefined,
       });
 
       this.streaming.buffer = "";
@@ -285,6 +287,7 @@ export const useChatStore = defineStore("chat", {
             load_duration_ms: m.load_duration_ms ?? 0,
             prompt_eval_duration_ms: m.prompt_eval_duration_ms ?? 0,
             eval_duration_ms: m.eval_duration_ms ?? 0,
+            seed: m.seed ?? undefined,
           };
         });
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -14,6 +14,7 @@ export interface Message {
   load_duration_ms?: number;
   prompt_eval_duration_ms?: number;
   eval_duration_ms?: number;
+  seed?: number;
   created_at?: string;
 }
 
@@ -32,6 +33,7 @@ export interface BackendMessage {
   load_duration_ms: number | null;
   prompt_eval_duration_ms: number | null;
   eval_duration_ms: number | null;
+  seed: number | null;
   created_at: string;
 }
 
@@ -115,6 +117,7 @@ export interface DonePayload {
   load_duration_ms: number;
   prompt_eval_duration_ms: number;
   eval_duration_ms: number;
+  seed?: number | null;
 }
 
 export interface ToolCallPayload {

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -684,6 +684,46 @@
                 />
               </div>
             </div>
+
+            <!-- Seed -->
+            <div class="settings-card gap-3">
+              <div>
+                <p class="text-[13.5px] font-bold text-[var(--text)]">Seed</p>
+                <p class="text-[12px] text-[var(--text-dim)] mt-0.5">
+                  Fixed integer for reproducible generation. Leave empty for
+                  random output.
+                </p>
+              </div>
+              <div class="flex items-center gap-3">
+                <input
+                  type="number"
+                  :value="settingsStore.chatOptions.seed ?? ''"
+                  @change="
+                    (() => {
+                      const v = ($event.target as HTMLInputElement).value;
+                      const n = parseInt(v, 10);
+                      settingsStore.updateChatOptions({
+                        seed: v === '' || Number.isNaN(n) ? undefined : n,
+                      });
+                    })()
+                  "
+                  placeholder="empty = random"
+                  class="w-40 bg-[var(--bg-input)] border border-[var(--border)] focus:border-[var(--accent)] text-[var(--text)] rounded-lg px-3 py-1.5 text-[12px] outline-none transition-colors"
+                  :class="
+                    settingsStore.chatOptions.seed !== undefined
+                      ? 'border-[var(--accent)] text-[var(--accent)]'
+                      : ''
+                  "
+                />
+                <button
+                  v-if="settingsStore.chatOptions.seed !== undefined"
+                  @click="settingsStore.updateChatOptions({ seed: undefined })"
+                  class="text-[11px] px-2 py-1 rounded-lg border border-[var(--border)] text-[var(--text-dim)] hover:text-[var(--text)] hover:border-[var(--border-strong)] transition-colors cursor-pointer"
+                >
+                  Reset to random
+                </button>
+              </div>
+            </div>
           </div>
         </Transition>
       </div>


### PR DESCRIPTION
## Summary

- Adds a numeric Seed input to the chat Advanced Options popover (bottom row, accent-highlighted when fixed)
- Adds a global Seed setting to the Settings page (after Stop Sequences)
- Emits the effective seed in the `chat:done` backend event
- Shows a seed badge in the StatsBlock summary row and a Seed row in the expanded table when a fixed seed was used

Closes #20

## Test plan

- [ ] Set a seed value in Advanced Options, send a message, verify seed badge appears in StatsBlock
- [ ] Clear seed (random button), send a message, verify no seed badge
- [ ] Set seed to 0, verify accent state activates (0 is valid)
- [ ] Set a global seed in Settings, start a new chat without overriding in Advanced Options, verify seed flows through
- [ ] Verify two identical prompts with the same fixed seed produce identical responses
- [ ] `pnpm format && pnpm test` passes
- [ ] `cargo test` passes