### PR TITLE
fix(e2e): replace racy pause(300) with waitForDisplayed in hosts.spec.ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       rust: ${{ steps.set.outputs.rust }}
       frontend: ${{ steps.set.outputs.frontend }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         id: filter
@@ -68,7 +68,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: crate-ci/typos@c96c46fae465ab9e3607401d9ce93d75e7998023 # v1
         with:
@@ -86,7 +86,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # @stable (master)
@@ -115,10 +115,10 @@ jobs:
         working-directory: src-tauri
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: pnpm
@@ -142,7 +142,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust 1.88.0 (MSRV)
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # @stable (master)
@@ -181,7 +181,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -229,11 +229,11 @@ jobs:
 
       - name: Setup pnpm
         if: needs.changes.outputs.frontend == 'true'
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: pnpm
@@ -294,7 +294,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -339,10 +339,10 @@ jobs:
         working-directory: src-tauri
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: pnpm
@@ -369,7 +369,7 @@ jobs:
 
       - name: Upload TypeScript coverage report
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: vitest-coverage
           path: coverage/
@@ -377,7 +377,7 @@ jobs:
 
       - name: Upload Rust coverage report
         if: needs.changes.outputs.rust == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: cargo-coverage
           path: src-tauri/coverage-rust/html/
@@ -395,7 +395,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # @stable (master)
@@ -425,10 +425,10 @@ jobs:
         run: cargo install tauri-driver --locked
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: pnpm
@@ -446,10 +446,11 @@ jobs:
 
       - name: Upload smoke test artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: smoke-artifacts
           path: e2e-desktop/.artifacts/
+          if-no-files-found: ignore
           retention-days: 7
 
   # ─────────────────────────────────────────────────────────────────────── #
@@ -463,7 +464,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # @stable (master)
@@ -493,10 +494,10 @@ jobs:
         run: cargo install tauri-driver --locked
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20
           cache: pnpm
@@ -523,9 +524,10 @@ jobs:
 
       - name: Upload integration test artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
           name: integration-artifacts
           path: e2e-desktop/.artifacts/
+          if-no-files-found: ignore
           retention-days: 7
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         language: [javascript-typescript, rust]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Install Rust stable (Rust analysis only)
         if: matrix.language == 'rust'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,7 +17,7 @@ jobs:
     name: Dependency Review
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       # 1. Checkout — full history so changelog generation works correctly  #
       # ------------------------------------------------------------------ #
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
@@ -85,7 +85,7 @@ jobs:
         # No 'version' key — reads from package.json "packageManager" field
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "20"
           cache: pnpm
@@ -209,7 +209,7 @@ jobs:
             echo "::notice::AUR_SSH_PRIVATE_KEY not configured — skipping AUR publish."
           fi
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         if: steps.guard.outputs.run == 'true'
 
       - name: Get version and AppImage sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - CL-05: Ollama Cloud routing — stored API key is now injected as `Authorization: Bearer` on all requests to `api.ollama.com` hosts. Missing key surfaces a friendly error in the chat rather than a raw network failure. Saving a key for the first time auto-adds the Ollama Cloud host entry.
 - MO-07: Model tags and favorites — star models as favorites to float them to the top of the model selector, apply custom text tags to organize local models, and filter by tag in both the local models tab and chat model selector.
 
+### Fixed
+- E2E: hosts.spec.ts `before()` hook now waits for the connectivity tab transition to complete (`waitForDisplayed`) instead of using a fixed 300ms pause, eliminating a race condition with Vue's `<Transition mode="out-in">` (~500ms) that caused intermittent CI failures (#75)
+
 ### Changed
 - CI: merge duplicate `test` + `coverage` jobs into single `test-and-coverage` (tests now run once with instrumentation instead of twice)
 - CI: add path-based job skipping — Rust-only PRs skip Vitest/TS checks; frontend-only PRs skip Rust compilation/testing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 - E2E: hosts.spec.ts `before()` hook now waits for the connectivity tab transition to complete (`waitForDisplayed`) instead of using a fixed 300ms pause, eliminating a race condition with Vue's `<Transition mode="out-in">` (~500ms) that caused intermittent CI failures (#75)
+- CI: updated all GitHub Actions to Node.js 24 runtimes (checkout v5.0.1, setup-node v5.0.0, pnpm/action-setup v4.1.0, upload-artifact v5.0.0); add `if-no-files-found: ignore` to E2E artifact upload steps; fix four TypeScript unused-variable lint warnings (#76)
 
 ### Changed
 - CI: merge duplicate `test` + `coverage` jobs into single `test-and-coverage` (tests now run once with instrumentation instead of twice)

--- a/e2e-desktop/integration/hosts.spec.ts
+++ b/e2e-desktop/integration/hosts.spec.ts
@@ -8,14 +8,12 @@ describe('Hosts — connectivity management', () => {
     await settings.clickNavIcon('settings')
     await $('[data-testid="settings-tab-connectivity"]').waitForDisplayed({ timeout: 5000 })
     await $('[data-testid="settings-tab-connectivity"]').click()
-    await browser.pause(300)
+    // Wait for the tab transition to complete before interacting (transition is ~500ms out-in)
+    const expandBtn = $('[data-testid="hosts-expand-btn"]')
+    await expandBtn.waitForDisplayed({ timeout: 5000 })
     // Expand the Ollama Hosts panel if not already expanded
-    const hostStatus = await $('[data-testid="host-status"]')
-    if (!(await hostStatus.isExisting())) {
-      const expandBtn = await $('[data-testid="hosts-expand-btn"]')
-      if (await expandBtn.isExisting()) {
-        await expandBtn.click()
-      }
+    if (!(await $('[data-testid="host-status"]').isExisting())) {
+      await expandBtn.click()
     }
     // Wait until the host list is visible
     await $('[data-testid="host-status"]').waitForExist({ timeout: 5000 })

--- a/src/components/models/LibraryBrowser.spec.ts
+++ b/src/components/models/LibraryBrowser.spec.ts
@@ -179,11 +179,6 @@ describe("LibraryBrowser", () => {
     const wrapper = mount(LibraryBrowser, { global: globalOpts });
     await nextTick();
 
-    // Should have "All" button + 3 unique tags (embedding, tools, vision sorted)
-    const chipButtons = wrapper.findAll(
-      ".flex.flex-wrap.gap-1\\.5 button, [class*='rounded-full'] button",
-    );
-
     // Check uniqueTags section is present
     expect(wrapper.text()).toContain("All");
     // All 3 unique tags should be visible

--- a/src/components/shared/MirostatSelector.vue
+++ b/src/components/shared/MirostatSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const props = defineProps<{
+defineProps<{
   modelValue: 0 | 1 | 2;
   compact?: boolean;
 }>();

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -269,7 +269,7 @@ describe("useChatStore", () => {
 
   it("compactConversation calls invoke('compact_conversation') and returns the new conversation ID", async () => {
     const store = useChatStore();
-    mockInvoke.mockImplementation(async (cmd, args) => {
+    mockInvoke.mockImplementation(async (cmd, _args) => {
       if (cmd === "compact_conversation") return "new-conv-id";
       if (cmd === "list_conversations") return [];
       if (cmd === "get_folder_contexts") return [];

--- a/src/stores/settings.test.ts
+++ b/src/stores/settings.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
-import { useSettingsStore, BUILTIN_PRESETS } from "./settings";
+import { useSettingsStore } from "./settings";
 import type { Preset, PresetOptions } from "../types/settings";
 
 const mockInvoke = vi.fn();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
       '**/e2e-desktop/**',
       '**/.{idea,git,cache,output,temp}/**',
       '**/.tabs/**',
+      '**/.worktrees/**',
+      '**/.claude/worktrees/**',
     ],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Summary

**E2E timing fix:**
- \`hosts.spec.ts\` \`before()\` hook used \`browser.pause(300)\` but Vue's \`<Transition mode=\"out-in\">\` takes ~500ms total. At T=300ms the connectivity tab panel isn't in the DOM yet, \`isExisting()\` returns false, the button is never clicked, and \`waitForExist\` times out. Fixed with \`expandBtn.waitForDisplayed({ timeout: 5000 })\`.

**GitHub Actions Node.js 24 migration** (across all 6 workflow files):
- \`actions/checkout\` v4.3.1 → v5.0.1
- \`actions/setup-node\` v4.4.0 → v5.0.0
- \`pnpm/action-setup\` old v4 → v4.1.0
- \`actions/upload-artifact\` v4.6.2 → v5.0.0
- Add \`if-no-files-found: ignore\` to E2E artifact upload steps (suppresses warning when tests pass and no screenshots exist)

**TypeScript unused-variable lint fixes:**
- \`settings.test.ts\`: remove unused \`BUILTIN_PRESETS\` import
- \`chat.test.ts\`: prefix unused \`args\` param with \`_\`
- \`MirostatSelector.vue\`: drop unused \`props\` variable
- \`LibraryBrowser.spec.ts\`: remove unused \`chipButtons\` assignment

**Vitest worktree exclusions:**
- Exclude \`.worktrees/**\` and \`.claude/worktrees/**\` so stale git worktrees don't duplicate or fail test runs

## Test plan

- [ ] CI / E2E Integration Tests job passes on push to develop
- [ ] No Node.js 20 deprecation warnings in any job
- [ ] Build Check shows no unused-variable warnings
- [ ] \`pnpm test\` runs 38 files / 446 tests with no failures locally

Closes #75