### PR TITLE
security: restrict API key attachment to https://api.ollama.com only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Security
+- API key is now restricted to `https://api.ollama.com` only: `is_cloud_host` requires HTTPS scheme, preventing the key from being attached to plaintext HTTP connections; `validate_api_key` rejects any host that is not the cloud endpoint before reading the key from the keyring
+
 ### Changed
 - Removed unused dependencies: `@types/lodash.throttle`, `ts-node` (frontend), `tracing-subscriber` (backend)
 

--- a/src-tauri/src/commands/auth/api_key.rs
+++ b/src-tauri/src/commands/auth/api_key.rs
@@ -116,6 +116,12 @@ pub async fn perform_validate_api_key(
 ) -> Result<bool, AppError> {
     let host_url = fetch_host_url(db, host_id.clone()).await?;
 
+    if !crate::ollama::client::is_cloud_host(&host_url) {
+        return Err(AppError::Auth(
+            "API key validation is only supported for the Ollama Cloud host (https://api.ollama.com).".into(),
+        ));
+    }
+
     let key = tokio::task::spawn_blocking(|| keyring::get_token(API_KEY_ACCOUNT)).await??;
     let key = match key {
         Some(k) => k,
@@ -261,18 +267,44 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_perform_validate_api_key_no_key_stored() {
-        // Verifies that perform_validate_api_key completes without panicking and
-        // returns a valid result. The keyring (API_KEY_ACCOUNT) is shared with
-        // other concurrently-running tests, so we cannot assert a specific Ok(true/false)
-        // value — we only assert the function does not return an unexpected error type.
+    async fn test_perform_validate_api_key_rejects_non_cloud_host() {
         let (client, db) = create_test_state();
         let host_id = {
             let conn = db.lock().unwrap();
             let hosts = crate::db::hosts::list_all(&conn).unwrap();
             hosts[0].id.clone()
         };
+        // The seeded default host is localhost — must be rejected before any network call.
+        let result = perform_validate_api_key(&client, db.clone(), host_id).await;
+        match result {
+            Err(AppError::Auth(msg)) if msg.contains("Ollama Cloud host") => (),
+            other => panic!("Expected Auth error for non-cloud host, got: {:?}", other),
+        }
+    }
 
+    #[tokio::test]
+    async fn test_perform_validate_api_key_no_key_stored() {
+        // Uses a cloud host entry so the host-restriction guard passes and we can
+        // exercise the "no key stored → Ok(false)" path. The keyring slot is shared
+        // with other tests, so we only assert on error type, not exact value.
+        let conn = rusqlite::Connection::open_in_memory().unwrap();
+        migrations::run(&conn).expect("migrations");
+        let db: DbConn = Arc::new(std::sync::Mutex::new(conn));
+        let host_id = {
+            let conn = db.lock().unwrap();
+            crate::db::hosts::create(
+                &conn,
+                crate::db::hosts::NewHost {
+                    name: "Ollama Cloud".into(),
+                    url: "https://api.ollama.com".into(),
+                    is_default: Some(true),
+                },
+            )
+            .expect("test setup: failed to create cloud host")
+            .id
+        };
+
+        let client = reqwest::Client::new();
         let result = perform_validate_api_key(&client, db.clone(), host_id).await;
         match result {
             Ok(_) => (),                      // Ok(true) or Ok(false) are both valid
@@ -283,7 +315,7 @@ mod tests {
                     || msg.contains("locked")
                     || msg.contains("Platform secure storage")
                     || msg.contains("ServiceUnknown") => {}
-            Err(AppError::NotFound(_)) => (), // Host not found in in-memory DB edge case
+            Err(AppError::NotFound(_)) => (), // Host not found edge case
             Err(e) => panic!("Unexpected error from perform_validate_api_key: {:?}", e),
         }
     }

--- a/src-tauri/src/ollama/client.rs
+++ b/src-tauri/src/ollama/client.rs
@@ -7,6 +7,7 @@ use reqwest::{Client, RequestBuilder};
 pub fn is_cloud_host(url: &str) -> bool {
     url::Url::parse(url)
         .ok()
+        .filter(|u| u.scheme() == "https")
         .and_then(|u| u.host_str().map(|h| h.to_lowercase()))
         .map(|h| h == "api.ollama.com")
         .unwrap_or(false)
@@ -101,7 +102,6 @@ mod tests {
     fn test_is_cloud_host_detects_api_ollama_com() {
         assert!(is_cloud_host("https://api.ollama.com"));
         assert!(is_cloud_host("https://api.ollama.com/"));
-        assert!(is_cloud_host("http://api.ollama.com"));
     }
 
     #[test]
@@ -110,6 +110,8 @@ mod tests {
         assert!(!is_cloud_host("http://127.0.0.1:11434"));
         assert!(!is_cloud_host("http://192.168.1.10:11434"));
         assert!(!is_cloud_host("https://my.custom-ollama.example.com"));
+        // Plaintext HTTP to cloud host must not be classified as cloud — key would leak.
+        assert!(!is_cloud_host("http://api.ollama.com"));
         // Subdomain-prefix attack: hostname contains "api.ollama.com" as a substring
         // but is a different domain. Must not be classified as cloud.
         assert!(!is_cloud_host("https://api.ollama.com.attacker.tld"));


### PR DESCRIPTION
## Summary

Fixes two vulnerabilities reported in issue #109 (P1 — API key can be sent to arbitrary or plaintext hosts):

- **`is_cloud_host` now requires `https://` scheme.** Previously only the hostname was checked, so a DB entry with `http://api.ollama.com` would be classified as cloud and the API key sent over plaintext HTTP. Added `.filter(|u| u.scheme() == "https")` to the URL parse chain.
- **`perform_validate_api_key` rejects non-cloud hosts before reading the key.** Previously any `host_id` could be passed and the key would be forwarded to the resolved URL unconditionally. The function now returns `AppError::Auth` immediately if the resolved URL is not `https://api.ollama.com`.

## Test plan

- [ ] `cargo test` — all 140 Rust tests pass including new `test_perform_validate_api_key_rejects_non_cloud_host`
- [ ] `pnpm test` — all 655 frontend tests pass
- [ ] `test_is_cloud_host_does_not_flag_local` now asserts `http://api.ollama.com` returns `false`
- [ ] `test_perform_validate_api_key_no_key_stored` updated to use a cloud host entry so it exercises the key-absent path

Closes #109