### PR TITLE
fix: stream lifecycle correctness — cancelled/errored streams treated as completed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ CLAUDE.md
 .playwright-mcp/
 .playwright-mcp.worktrees/
 .worktrees/
+.agents/
+.codex/
 
 # Test and coverage output
 test-results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+- Cancelling generation (Stop button or Esc) no longer emits `chat:done`, persists a partial message to the database, or triggers a completion notification; partial content is preserved in-session via the new `chat:cancelled` event
+- Esc key now correctly clears the streaming indicator (previously `isStreaming` stayed true after pressing Esc)
+- Network chunk errors mid-stream no longer emit a duplicate `chat:done` or persist the partial response as a completed message
+
 ### Security
 - API key is now restricted to `https://api.ollama.com` only: `is_cloud_host` requires HTTPS scheme, preventing the key from being attached to plaintext HTTP connections; `validate_api_key` rejects any host that is not the cloud endpoint before reading the key from the keyring
 

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -50,6 +50,9 @@ pub enum AppError {
 
     #[error("Validation error: {0}")]
     Validation(String),
+
+    #[error("Generation cancelled")]
+    Cancelled,
 }
 
 // ── Conversions ────────────────────────────────────────────────────────────────

--- a/src-tauri/src/ollama/streaming.rs
+++ b/src-tauri/src/ollama/streaming.rs
@@ -86,7 +86,10 @@ async fn stream_once<R: Runtime>(
     loop {
         tokio::select! {
             _ = cancel_rx.recv() => {
-                break;
+                let _ = app.emit("chat:cancelled", serde_json::json!({
+                    "conversation_id": conversation_id,
+                }));
+                return Err(AppError::Cancelled);
             }
             chunk_res = stream.next() => {
                 match chunk_res {
@@ -279,25 +282,13 @@ async fn stream_once<R: Runtime>(
                             assembled.len(),
                             e
                         );
-                        // If any content was already streamed to the frontend, emit
-                        // chat:done first so the frontend can persist the partial
-                        // response. Without this, the UI stays in "streaming" state
-                        // indefinitely even though the user already saw the tokens.
-                        if !assembled.is_empty() {
-                            let _ = app.emit("chat:done", json!({
-                                "conversation_id": conversation_id,
-                                "total_tokens": 0,
-                                "duration_ms": 0,
-                                "tokens_per_sec": 0.0
-                            }));
-                        }
                         if let Err(emit_err) = app.emit("chat:error", json!({
                             "conversation_id": conversation_id,
                             "error": e.to_string()
                         })) {
                             log::warn!("Failed to emit chat:error: {} — continuing stream", emit_err);
                         }
-                        break;
+                        return Err(AppError::Http(e.to_string()));
                     }
                     None => {
                         if assembled.is_empty() {
@@ -309,22 +300,4 @@ async fn stream_once<R: Runtime>(
             }
         }
     }
-
-    Ok(StreamResult {
-        content: assembled,
-        thinking: if thinking_assembled.is_empty() {
-            None
-        } else {
-            Some(thinking_assembled)
-        },
-        tokens_used: None,
-        generation_time_ms: None,
-        prompt_tokens: None,
-        tokens_per_sec: None,
-        total_duration_ms: None,
-        load_duration_ms: None,
-        prompt_eval_duration_ms: None,
-        eval_duration_ms: None,
-        tool_calls: None,
-    })
 }

--- a/src-tauri/src/services/chat/mod.rs
+++ b/src-tauri/src/services/chat/mod.rs
@@ -236,7 +236,7 @@ impl<'a, R: Runtime> ChatService<'a, R> {
         }
 
         // 5. Orchestrate (agent loop, event emission)
-        let result = tokio::time::timeout(
+        let orchestrate_result = tokio::time::timeout(
             Duration::from_secs(300),
             self.orchestrate_stream_with_context(
                 conversation_id.clone(),
@@ -259,7 +259,13 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                 }),
             );
             AppError::Internal("Agent loop timed out after 300s".into())
-        })??;
+        })?;
+
+        let result = match orchestrate_result {
+            Ok(r) => r,
+            Err(AppError::Cancelled) => return Ok(()),
+            Err(e) => return Err(e),
+        };
 
         // 6. Persist assistant message (match existing behavior: always persist when content non-empty)
         if !result.content.is_empty() {

--- a/src-tauri/src/services/chat/orchestrator.rs
+++ b/src-tauri/src/services/chat/orchestrator.rs
@@ -106,6 +106,9 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                     .await
                 {
                     Ok(r) => r,
+                    Err(crate::error::AppError::Cancelled) => {
+                        return Err(crate::error::AppError::Cancelled);
+                    }
                     Err(e) => {
                         let err_msg = e.to_string();
                         crate::system::notifications::notify_generation_failed(

--- a/src/composables/useKeyboard.ts
+++ b/src/composables/useKeyboard.ts
@@ -32,7 +32,11 @@ export function useKeyboard() {
     if (e.key === "Escape") {
       if (chatStore.isStreamingForActiveConv) {
         e.preventDefault();
-        invoke("stop_generation").catch(() => {});
+        invoke("stop_generation")
+          .catch(() => {})
+          .finally(() => {
+            chatStore.streaming.isStreaming = false;
+          });
       }
       return;
     }

--- a/src/composables/useStreaming.test.ts
+++ b/src/composables/useStreaming.test.ts
@@ -32,7 +32,7 @@ describe("useStreaming", () => {
 
     await listenersReady;
 
-    expect(mockListen).toHaveBeenCalledTimes(8);
+    expect(mockListen).toHaveBeenCalledTimes(9);
     const events = mockListen.mock.calls.map(([event]) => event);
     expect(events).toContain("chat:token");
     expect(events).toContain("chat:thinking-start");
@@ -42,6 +42,7 @@ describe("useStreaming", () => {
     expect(events).toContain("chat:tool-call");
     expect(events).toContain("chat:tool-result");
     expect(events).toContain("chat:error");
+    expect(events).toContain("chat:cancelled");
   });
 
   it("onToken callback is NOT called for tokens belonging to a different conversation", async () => {

--- a/src/composables/useStreaming.test.ts
+++ b/src/composables/useStreaming.test.ts
@@ -121,6 +121,67 @@ describe("useStreaming", () => {
     unlistenFns.forEach((fn) => expect(fn).toHaveBeenCalled());
   });
 
+  it("onCancelled callback is called when chat:cancelled fires for the active conversation", async () => {
+    const convId = ref<string | null>("active-conv-id");
+    const onCancelled = vi.fn();
+    const { listenersReady } = useStreaming(convId, { onCancelled });
+
+    await listenersReady;
+
+    const handler = mockListen.mock.calls.find(
+      ([e]) => e === "chat:cancelled",
+    )?.[1];
+    expect(handler).toBeDefined();
+    handler({ payload: { conversation_id: "active-conv-id" } });
+
+    expect(onCancelled).toHaveBeenCalledWith("active-conv-id");
+  });
+
+  it("onCancelled callback is NOT called when chat:cancelled fires for a different conversation", async () => {
+    const convId = ref<string | null>("active-conv-id");
+    const onCancelled = vi.fn();
+    const { listenersReady } = useStreaming(convId, { onCancelled });
+
+    await listenersReady;
+
+    const handler = mockListen.mock.calls.find(
+      ([e]) => e === "chat:cancelled",
+    )?.[1];
+    handler({ payload: { conversation_id: "OTHER-conv" } });
+
+    expect(onCancelled).not.toHaveBeenCalled();
+  });
+
+  it("reset() clears buffers and sets isStreaming to true", async () => {
+    const convId = ref<string | null>(null);
+    const {
+      listenersReady,
+      reset,
+      buffer,
+      thinkingBuffer,
+      isThinking,
+      isStreaming,
+      tokensPerSec,
+    } = useStreaming(convId);
+
+    await listenersReady;
+
+    // Mutate state to non-default values
+    buffer.value = "some content";
+    thinkingBuffer.value = "thinking...";
+    isThinking.value = true;
+    isStreaming.value = false;
+    tokensPerSec.value = 42;
+
+    reset();
+
+    expect(buffer.value).toBe("");
+    expect(thinkingBuffer.value).toBe("");
+    expect(isThinking.value).toBe(false);
+    expect(isStreaming.value).toBe(true);
+    expect(tokensPerSec.value).toBeNull();
+  });
+
   it("composable does not call onUnmounted — cleanup is explicit only", async () => {
     // This test documents that useStreaming does NOT rely on Vue component
     // lifecycle hooks. The composable is safe to call from a Pinia store.

--- a/src/composables/useStreaming.ts
+++ b/src/composables/useStreaming.ts
@@ -15,6 +15,7 @@ export interface StreamingCallbacks {
   onThinkingToken?: (payload: ThinkingTokenPayload) => void;
   onThinkingEnd?: (conversationId: string, durationMs?: number) => void;
   onDone?: (payload: DonePayload) => void;
+  onCancelled?: (conversationId: string) => void;
   onError?: (conversationId: string, error: string) => void;
   onToolCall?: (payload: ToolCallPayload) => void;
   onToolResult?: (payload: ToolResultPayload) => void;
@@ -136,6 +137,18 @@ export function useStreaming(
       callbacks.onError?.(event.payload.conversation_id, event.payload.error);
     });
 
+    const unlistenCancelled = await listen<{ conversation_id: string }>(
+      "chat:cancelled",
+      (event) => {
+        if (
+          conversationId.value &&
+          event.payload.conversation_id !== conversationId.value
+        )
+          return;
+        callbacks.onCancelled?.(event.payload.conversation_id);
+      },
+    );
+
     unlisteners.push(
       unlistenToken,
       unlistenThinkingStart,
@@ -145,6 +158,7 @@ export function useStreaming(
       unlistenToolCall,
       unlistenToolResult,
       unlistenError,
+      unlistenCancelled,
     );
   }
 

--- a/src/composables/useStreamingEvents.ts
+++ b/src/composables/useStreamingEvents.ts
@@ -89,6 +89,10 @@ export function useStreamingEvents() {
         chatStore.streaming.isStreaming = false;
         chatStore.streaming.tokensPerSec = payload.tokens_per_sec;
       },
+      onCancelled: (convId) => {
+        chatStore.finalizeStreamedMessage(convId);
+        chatStore.streaming.isStreaming = false;
+      },
       onError: (_convId, error) => {
         console.error("Chat stream error:", error);
         if (!chatStore.streaming.buffer.trim()) {


### PR DESCRIPTION
Closes #111

## Summary

- `streaming.rs`: `cancel_rx.recv()` now returns `Err(AppError::Cancelled)` instead of `break → Ok` fallthrough; emits `chat:cancelled` first so the frontend can finalize the partial response in-session
- `streaming.rs`: network chunk error path returns `Err(AppError::Http)` directly, removing the inline `chat:done` that caused the orchestrator to emit a second `chat:done` and persist a partial message as completed
- `orchestrator.rs`: `Err(Cancelled)` exits early — skips `chat:done`, all notifications, and DB persistence
- `mod.rs` (`send`): `Err(Cancelled)` → `Ok(())` — user-initiated stop is not an error
- Frontend: `useStreaming.ts` + `useStreamingEvents.ts` handle `chat:cancelled` via `finalizeStreamedMessage` so partial content stays visible in-session
- Frontend: `useKeyboard.ts` Esc handler now sets `isStreaming = false`

## Test Plan

- [ ] Click Stop mid-stream — partial response stays visible, no OS "generation complete" notification, no DB persistence on reload
- [ ] Press Esc mid-stream — same as above, streaming indicator clears
- [ ] Simulate network error mid-stream — `chat:error` shown, no duplicate `chat:done`, no partial message persisted as completed
- [ ] Normal completion — `chat:done` still fires, message persisted correctly
- [ ] `test_stop_generation_cancels_stream` passes (was the failing integration test)