### PR TITLE
fix: draft persistence, file-context propagation, capability hardening, and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Cancelling generation (Stop button or Esc) no longer emits `chat:done`, persists a partial message to the database, or triggers a completion notification; partial content is preserved in-session via the new `chat:cancelled` event
 - Esc key now correctly clears the streaming indicator (previously `isStreaming` stayed true after pressing Esc)
 - Network chunk errors mid-stream no longer emit a duplicate `chat:done` or persist the partial response as a completed message
+- Draft message input is now correctly saved to the database; IPC parameter casing mismatch (`conversation_id`/`draft_json` → `conversationId`/`draftJson`) prevented persistence silently
+- Clearing a draft on an unsaved conversation no longer logs "Conversation not found" warnings
+- Linked file context (text files attached via "Link File Context") is now correctly passed to the model; non-UTF-8 and permission-denied files previously returned empty content silently
+- File link errors in the chat input now show the actual backend error message instead of a generic fallback
+
+### Security
+- Tauri capability narrowed from broad `fs:allow-read-file` to a scoped `read_image_file` command with an extension allowlist (`jpg`, `jpeg`, `png`, `gif`, `webp`, `bmp`) and 20 MB size guard; unused `opener:allow-open-path` capability removed
 
 ### Security
 - API key is now restricted to `https://api.ollama.com` only: `is_cloud_host` requires HTTPS scheme, preventing the key from being attached to plaintext HTTP connections; `validate_api_key` rejects any host that is not the cloud endpoint before reading the key from the keyring

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -12,8 +12,6 @@
     "dialog:allow-save",
     "notification:default",
     "global-shortcut:default",
-    "opener:allow-open-url",
-    "opener:allow-open-path",
-    "fs:allow-read-file"
+    "opener:allow-open-url"
   ]
 }

--- a/src-tauri/src/commands/attachments.rs
+++ b/src-tauri/src/commands/attachments.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+/// Reads an image file from the local filesystem with strict validation.
+///
+/// Permitted extensions: jpg, jpeg, png, gif, webp, bmp (case-insensitive).
+/// Maximum file size: 20 MB.
+///
+/// This command replaces the broad `fs:allow-read-file` capability permission
+/// with a narrow, extension- and size-checked path that the frontend uses for
+/// drag-and-drop image attachments.
+#[tauri::command]
+pub async fn read_image_file(path: String) -> Result<Vec<u8>, String> {
+    const MAX_SIZE: u64 = 20 * 1024 * 1024; // 20 MB
+    const ALLOWED_EXTENSIONS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp"];
+
+    // Validate extension
+    let extension = Path::new(&path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .ok_or_else(|| "File has no extension or extension is invalid".to_string())?;
+
+    if !ALLOWED_EXTENSIONS.contains(&extension.as_str()) {
+        return Err(format!(
+            "File extension '{}' is not permitted. Allowed: {}",
+            extension,
+            ALLOWED_EXTENSIONS.join(", ")
+        ));
+    }
+
+    // Check file size before reading
+    let metadata = tokio::fs::metadata(&path)
+        .await
+        .map_err(|e| format!("Failed to read file metadata: {e}"))?;
+
+    if metadata.len() > MAX_SIZE {
+        return Err(format!(
+            "File size {} bytes exceeds the 20 MB limit",
+            metadata.len()
+        ));
+    }
+
+    // Read file bytes
+    tokio::fs::read(&path)
+        .await
+        .map_err(|e| format!("Failed to read image file: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[tokio::test]
+    async fn rejects_missing_extension() {
+        let result = read_image_file("/tmp/imagewithoutextension".to_string()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("no extension"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_disallowed_extension() {
+        let result = read_image_file("/tmp/document.pdf".to_string()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("not permitted"), "got: {err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_executable_extension() {
+        let result = read_image_file("/tmp/malware.exe".to_string()).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn accepts_valid_image_extension_and_reads_bytes() {
+        let mut file = NamedTempFile::with_suffix(".png").unwrap();
+        let data = b"\x89PNG\r\n\x1a\nfake";
+        file.write_all(data).unwrap();
+
+        let path = file.path().to_str().unwrap().to_string();
+        let result = read_image_file(path).await;
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+        assert_eq!(result.unwrap(), data);
+    }
+
+    #[tokio::test]
+    async fn accepts_uppercase_extension() {
+        let mut file = NamedTempFile::with_suffix(".JPEG").unwrap();
+        file.write_all(b"fake jpeg").unwrap();
+
+        let path = file.path().to_str().unwrap().to_string();
+        let result = read_image_file(path).await;
+        assert!(result.is_ok(), "expected Ok, got: {:?}", result);
+    }
+
+    #[tokio::test]
+    async fn rejects_nonexistent_file_with_valid_extension() {
+        let result = read_image_file("/tmp/nonexistent_file_abc123.png".to_string()).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.contains("metadata"), "got: {err}");
+    }
+}

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -91,16 +91,17 @@ pub fn read_folder_context(folder_path: &Path) -> Result<FolderContextPayload, A
             ));
         }
 
-        if let Ok(file_content) = std::fs::read_to_string(folder_path) {
-            if file_content.len() > MAX_FOLDER_CONTEXT_SIZE {
-                return Err(AppError::Internal("File exceeds 50MB limit".into()));
-            }
-            let filename = folder_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("file");
-            content.push_str(&format!("\n--- File: {} ---\n{}\n", filename, file_content));
+        let bytes = std::fs::read(folder_path)
+            .map_err(|e| AppError::Io(format!("Failed to read file: {}", e)))?;
+        if bytes.len() > MAX_FOLDER_CONTEXT_SIZE {
+            return Err(AppError::Internal("File exceeds 50MB limit".into()));
         }
+        let file_content = String::from_utf8_lossy(&bytes);
+        let filename = folder_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("file");
+        content.push_str(&format!("\n--- File: {} ---\n{}\n", filename, file_content));
 
         let token_estimate = content.chars().count() / 4;
         return Ok(FolderContextPayload {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod attachments;
 pub mod auth;
 pub mod chat;
 pub mod folders;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,7 @@ pub fn run() {
             commands::system_info::detect_hardware,
             commands::system::report_active_view,
             commands::system::open_browser,
+            commands::attachments::read_image_file,
         ])
         .setup(|app| {
             // ── Logging (MED-08: enabled in all builds) ────────────────────────
@@ -148,7 +149,7 @@ pub fn run() {
 
             // ── Hosts Manager ──────────────────────────────────────────────────
             #[cfg(feature = "test-mode")]
-            let _ = shutdown_rx;
+            drop(shutdown_rx);
             #[cfg(not(feature = "test-mode"))]
             {
                 let health_handle =

--- a/src-tauri/src/services/chat/orchestrator.rs
+++ b/src-tauri/src/services/chat/orchestrator.rs
@@ -79,31 +79,40 @@ impl<'a, R: Runtime> ChatService<'a, R> {
             .map_err(|_| AppError::Internal("Cancel lock poisoned".into()))? =
             Some(cancel_tx.clone());
 
-        let mut current_messages = initial_messages;
-        let mut final_content = String::new();
-        let mut metrics = AssistantMetrics::default();
+        // Run the generation loop inside an async block so cancel_tx cleanup
+        // happens unconditionally at a single site, regardless of how the loop exits
+        // (normal completion, cancellation, tool-call error, or any `?` propagation).
+        let generation_result: Result<OrchestrationResult, AppError> = async {
+            let mut current_messages = initial_messages;
+            let mut final_content = String::new();
+            let mut metrics = AssistantMetrics::default();
 
-        let mut iteration = 0;
-        loop {
-            iteration += 1;
-            if iteration > 5 {
-                log::warn!("Agent loop exceeded max iterations");
-                break;
-            }
+            let mut iteration = 0;
+            loop {
+                iteration += 1;
+                if iteration > 5 {
+                    log::warn!("Agent loop exceeded max iterations");
+                    break;
+                }
 
-            let req = ChatRequest {
-                model: model.clone(),
-                messages: current_messages.clone(),
-                stream: true,
-                think: think.clone(),
-                tools: tools.clone(),
-                options: options.clone(),
-            };
+                let req = ChatRequest {
+                    model: model.clone(),
+                    messages: current_messages.clone(),
+                    stream: true,
+                    think: think.clone(),
+                    tools: tools.clone(),
+                    options: options.clone(),
+                };
 
-            let cancel_rx = cancel_tx.subscribe();
-            let result =
-                match streaming::stream_chat(&self.app, &client, req, &conversation_id, cancel_rx)
-                    .await
+                let cancel_rx = cancel_tx.subscribe();
+                let result = match streaming::stream_chat(
+                    &self.app,
+                    &client,
+                    req,
+                    &conversation_id,
+                    cancel_rx,
+                )
+                .await
                 {
                     Ok(r) => r,
                     Err(crate::error::AppError::Cancelled) => {
@@ -120,127 +129,137 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                     }
                 };
 
-            // Aggregate results
-            final_content.push_str(&result.content);
-            metrics.tokens_used =
-                Some(metrics.tokens_used.unwrap_or(0) + result.tokens_used.unwrap_or(0));
+                // Aggregate results
+                final_content.push_str(&result.content);
+                metrics.tokens_used =
+                    Some(metrics.tokens_used.unwrap_or(0) + result.tokens_used.unwrap_or(0));
 
-            if let Some(t) = result.generation_time_ms {
-                metrics.generation_time_ms = Some(metrics.generation_time_ms.unwrap_or(0) + t);
-            }
-            if let Some(pt) = result.prompt_tokens {
-                // Usually we take the prompt tokens from the last turn or the peak
-                metrics.prompt_tokens = Some(pt);
-            }
-            if let Some(tps) = result.tokens_per_sec {
-                // Using TPS from the last turn is generally indicative
-                metrics.tokens_per_sec = Some(tps);
-            }
-            if let Some(td) = result.total_duration_ms {
-                metrics.total_duration_ms = Some(metrics.total_duration_ms.unwrap_or(0) + td);
-            }
-            if let Some(ld) = result.load_duration_ms {
-                metrics.load_duration_ms = Some(metrics.load_duration_ms.unwrap_or(0) + ld);
-            }
-            if let Some(ped) = result.prompt_eval_duration_ms {
-                metrics.prompt_eval_duration_ms =
-                    Some(metrics.prompt_eval_duration_ms.unwrap_or(0) + ped);
-            }
-            if let Some(ed) = result.eval_duration_ms {
-                metrics.eval_duration_ms = Some(metrics.eval_duration_ms.unwrap_or(0) + ed);
-            }
+                if let Some(t) = result.generation_time_ms {
+                    metrics.generation_time_ms = Some(metrics.generation_time_ms.unwrap_or(0) + t);
+                }
+                if let Some(pt) = result.prompt_tokens {
+                    // Usually we take the prompt tokens from the last turn or the peak
+                    metrics.prompt_tokens = Some(pt);
+                }
+                if let Some(tps) = result.tokens_per_sec {
+                    // Using TPS from the last turn is generally indicative
+                    metrics.tokens_per_sec = Some(tps);
+                }
+                if let Some(td) = result.total_duration_ms {
+                    metrics.total_duration_ms = Some(metrics.total_duration_ms.unwrap_or(0) + td);
+                }
+                if let Some(ld) = result.load_duration_ms {
+                    metrics.load_duration_ms = Some(metrics.load_duration_ms.unwrap_or(0) + ld);
+                }
+                if let Some(ped) = result.prompt_eval_duration_ms {
+                    metrics.prompt_eval_duration_ms =
+                        Some(metrics.prompt_eval_duration_ms.unwrap_or(0) + ped);
+                }
+                if let Some(ed) = result.eval_duration_ms {
+                    metrics.eval_duration_ms = Some(metrics.eval_duration_ms.unwrap_or(0) + ed);
+                }
 
-            // Handle tool calls
-            if let Some(tool_calls) = result.tool_calls {
-                // Add the assistant's response that requested the tool call to history
-                current_messages.push(Message {
-                    role: "assistant".to_string(),
-                    content: result.content.clone(),
-                    images: None,
-                    thinking: result.thinking.clone(),
-                    tool_calls: Some(tool_calls.clone()), // Mirror tool calls back
-                    name: None,
-                });
+                // Handle tool calls
+                if let Some(tool_calls) = result.tool_calls {
+                    // Add the assistant's response that requested the tool call to history
+                    current_messages.push(Message {
+                        role: "assistant".to_string(),
+                        content: result.content.clone(),
+                        images: None,
+                        thinking: result.thinking.clone(),
+                        tool_calls: Some(tool_calls.clone()), // Mirror tool calls back
+                        name: None,
+                    });
 
-                let (mut tool_responses, any_succeeded, tool_results) =
-                    if let Some(user_content) = original_user_content {
-                        search_service
-                            .handle_tool_calls_with_context(
-                                &conversation_id,
-                                tool_calls,
-                                &client,
-                                user_content,
-                            )
-                            .await?
+                    let (mut tool_responses, any_succeeded, tool_results) =
+                        if let Some(user_content) = original_user_content {
+                            search_service
+                                .handle_tool_calls_with_context(
+                                    &conversation_id,
+                                    tool_calls,
+                                    &client,
+                                    user_content,
+                                )
+                                .await?
+                        } else {
+                            search_service
+                                .handle_tool_calls(&conversation_id, tool_calls, &client)
+                                .await?
+                        };
+
+                    for (tc, result_text) in tool_results {
+                        let query = tc
+                            .function
+                            .arguments
+                            .get("query")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        final_content.push_str(&format!(
+                            "\n<tool_call name=\"{}\" query=\"{}\">{}</tool_call>\n",
+                            tc.function.name, query, result_text
+                        ));
+                    }
+
+                    // If every tool call in this iteration failed, break immediately
+                    if !any_succeeded && !tool_responses.is_empty() {
+                        log::warn!(
+                            "All tool calls failed in agent iteration {}; aborting loop",
+                            iteration
+                        );
+                        break;
+                    }
+
+                    if !tool_responses.is_empty() {
+                        current_messages.append(&mut tool_responses);
+                        // Continue to next turn of the agent loop
+                        continue;
                     } else {
-                        search_service
-                            .handle_tool_calls(&conversation_id, tool_calls, &client)
-                            .await?
-                    };
-
-                for (tc, result_text) in tool_results {
-                    let query = tc
-                        .function
-                        .arguments
-                        .get("query")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
-                    final_content.push_str(&format!(
-                        "\n<tool_call name=\"{}\" query=\"{}\">{}</tool_call>\n",
-                        tc.function.name, query, result_text
-                    ));
-                }
-
-                // If every tool call in this iteration failed, break immediately
-                if !any_succeeded && !tool_responses.is_empty() {
-                    log::warn!(
-                        "All tool calls failed in agent iteration {}; aborting loop",
-                        iteration
-                    );
-                    break;
-                }
-
-                if !tool_responses.is_empty() {
-                    current_messages.append(&mut tool_responses);
-                    // Continue to next turn of the agent loop
-                    continue;
+                        break;
+                    }
                 } else {
+                    // No tool calls, generation is complete
                     break;
                 }
-            } else {
-                // No tool calls, generation is complete
-                break;
             }
+
+            metrics.seed = options.as_ref().and_then(|o| o.seed);
+
+            // Emit final done event after all agent turns are complete
+            let _ = self.app.emit(
+                "chat:done",
+                json!({
+                    "conversation_id": conversation_id,
+                    "total_tokens": metrics.tokens_used,
+                    "duration_ms": metrics.generation_time_ms,
+                    "prompt_tokens": metrics.prompt_tokens,
+                    "tokens_per_sec": metrics.tokens_per_sec,
+                    "total_duration_ms": metrics.total_duration_ms,
+                    "load_duration_ms": metrics.load_duration_ms,
+                    "prompt_eval_duration_ms": metrics.prompt_eval_duration_ms,
+                    "eval_duration_ms": metrics.eval_duration_ms,
+                    "seed": metrics.seed,
+                }),
+            );
+
+            crate::system::notifications::notify_generation_complete(
+                &self.app,
+                &model,
+                &conversation_id,
+            );
+
+            Ok(OrchestrationResult {
+                content: final_content,
+                metrics,
+            })
+        }
+        .await;
+
+        // Unconditionally clear the stored sender so it doesn't outlive this generation.
+        // Swallow a poisoned lock here to avoid masking the real generation error.
+        if let Ok(mut guard) = self.state.cancel_tx.lock() {
+            *guard = None;
         }
 
-        metrics.seed = options.as_ref().and_then(|o| o.seed);
-
-        // Emit final done event after all agent turns are complete
-        let _ = self.app.emit(
-            "chat:done",
-            json!({
-                "conversation_id": conversation_id,
-                "total_tokens": metrics.tokens_used,
-                "duration_ms": metrics.generation_time_ms,
-                "prompt_tokens": metrics.prompt_tokens,
-                "tokens_per_sec": metrics.tokens_per_sec,
-                "total_duration_ms": metrics.total_duration_ms,
-                "load_duration_ms": metrics.load_duration_ms,
-                "prompt_eval_duration_ms": metrics.prompt_eval_duration_ms,
-                "eval_duration_ms": metrics.eval_duration_ms,
-                "seed": metrics.seed,
-            }),
-        );
-
-        crate::system::notifications::notify_generation_complete(
-            &self.app,
-            &model,
-            &conversation_id,
-        );
-
-        Ok(OrchestrationResult {
-            content: final_content,
-            metrics,
-        })
+        generation_result
     }
 }

--- a/src/components/chat/ChatInput.spec.ts
+++ b/src/components/chat/ChatInput.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { setActivePinia, createPinia } from "pinia";
 import ChatInput from "./ChatInput.vue";
@@ -600,6 +600,172 @@ describe("ChatInput — Model defaults on selection", () => {
 
     await expect(vm.selectModel("llama3")).resolves.not.toThrow();
     expect(vm.chatOptions).toEqual({});
+  });
+});
+
+describe("ChatInput — Link error display", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    mockInvoke.mockImplementation(() => Promise.resolve([]));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("showLinkError sets linkError and auto-clears after 4 s", async () => {
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      showLinkError: (msg: string) => void;
+      linkError: string | null;
+    };
+
+    vm.showLinkError("Something went wrong");
+    await wrapper.vm.$nextTick();
+
+    expect(vm.linkError).toBe("Something went wrong");
+
+    vi.advanceTimersByTime(4000);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.linkError).toBeNull();
+  });
+
+  it("showLinkError cancels a previous pending timer on repeated calls", async () => {
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      showLinkError: (msg: string) => void;
+      linkError: string | null;
+    };
+
+    vm.showLinkError("first error");
+    await wrapper.vm.$nextTick();
+    vi.advanceTimersByTime(2000);
+
+    vm.showLinkError("second error");
+    await wrapper.vm.$nextTick();
+    vi.advanceTimersByTime(2000);
+
+    // first timer would have cleared it at t=4000; second timer resets the clock
+    expect(vm.linkError).toBe("second error");
+
+    vi.advanceTimersByTime(2000);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.linkError).toBeNull();
+  });
+
+  it("renders the linkError message in the template", async () => {
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      showLinkError: (msg: string) => void;
+    };
+
+    vm.showLinkError("File is binary");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("File is binary");
+  });
+
+  it("pickContext shows a Tauri plain-string error when link_folder rejects", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    vi.mocked(open).mockResolvedValueOnce("/home/user/notes.txt");
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "link_folder")
+        return Promise.reject("File is binary or unreadable");
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      pickContext: (isFolder: boolean) => Promise<void>;
+      linkError: string | null;
+    };
+
+    await vm.pickContext(false);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.linkError).toBe("File is binary or unreadable");
+  });
+
+  it("pickContext shows a fallback message when a non-string non-Error is thrown", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+
+    const { open } = await import("@tauri-apps/plugin-dialog");
+    vi.mocked(open).mockResolvedValueOnce("/home/user/doc.txt");
+
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "link_folder") return Promise.reject({ code: 42 });
+      return Promise.resolve([]);
+    });
+
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      pickContext: (isFolder: boolean) => Promise<void>;
+      linkError: string | null;
+    };
+
+    await vm.pickContext(false);
+    await wrapper.vm.$nextTick();
+
+    expect(vm.linkError).toBe(
+      "Failed to link file — binary or unreadable files cannot be used as context.",
+    );
+  });
+});
+
+describe("ChatInput — onBeforeUnmount cleanup", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.useFakeTimers();
+    mockInvoke.mockImplementation(() => Promise.resolve([]));
+    global.URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears linkErrorTimer on unmount so it does not fire after teardown", async () => {
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      showLinkError: (msg: string) => void;
+      linkError: string | null;
+    };
+
+    vm.showLinkError("pending error");
+    await wrapper.vm.$nextTick();
+    expect(vm.linkError).toBe("pending error");
+
+    wrapper.unmount();
+
+    // Advancing past the timer should not throw (cleared) and linkError stays put
+    expect(() => vi.advanceTimersByTime(5000)).not.toThrow();
+  });
+
+  it("clears attachments on unmount", async () => {
+    const wrapper = mountInput();
+    const vm = wrapper.vm as unknown as {
+      handleFiles: (files: File[]) => Promise<void>;
+      attachments: { file: File; previewUrl: string }[];
+    };
+
+    const file = new File(["x"], "img.png", { type: "image/png" });
+    await vm.handleFiles([file]);
+    expect(vm.attachments).toHaveLength(1);
+
+    wrapper.unmount();
+
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
   });
 });
 

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -52,6 +52,17 @@ const activeConvId = computed(() => chatStore.activeConversationId);
 
 // ---- Linked Context ----
 const isLinking = ref(false);
+const linkError = ref<string | null>(null);
+let linkErrorTimer: ReturnType<typeof setTimeout> | null = null;
+
+function showLinkError(msg: string) {
+  linkError.value = msg;
+  if (linkErrorTimer) clearTimeout(linkErrorTimer);
+  linkErrorTimer = setTimeout(() => {
+    linkError.value = null;
+    linkErrorTimer = null;
+  }, 4000);
+}
 
 async function pickContext(isFolder: boolean) {
   if (!activeConvId.value) return;
@@ -81,6 +92,13 @@ async function pickContext(isFolder: boolean) {
     });
   } catch (err) {
     console.error("Failed to link context:", err);
+    showLinkError(
+      typeof err === "string"
+        ? err
+        : err instanceof Error
+          ? err.message
+          : "Failed to link file — binary or unreadable files cannot be used as context.",
+    );
   } finally {
     isLinking.value = false;
   }
@@ -304,6 +322,13 @@ const {
       });
     } catch (err) {
       console.error("Failed to link dropped file:", err);
+      showLinkError(
+        typeof err === "string"
+          ? err
+          : err instanceof Error
+            ? err.message
+            : "Failed to link file — binary or unreadable files cannot be used as context.",
+      );
     } finally {
       isLinking.value = false;
     }
@@ -463,11 +488,13 @@ onMounted(async () => {
 });
 
 onBeforeUnmount(() => {
+  if (linkErrorTimer) clearTimeout(linkErrorTimer);
   appEvents.removeEventListener(
     APP_EVENT.OPEN_MODEL_SWITCHER,
     onOpenModelSwitcher,
   );
   unlistenDrag?.();
+  clearAttachments();
 });
 </script>
 
@@ -518,6 +545,11 @@ onBeforeUnmount(() => {
         class="absolute inset-0 z-30 bg-[var(--accent-muted)] backdrop-blur-[2px] border-2 border-dashed border-[var(--accent)] flex items-center justify-center pointer-events-none rounded-[20px]"
       >
         <span class="text-[var(--accent)] font-medium">Drop images here</span>
+      </div>
+
+      <!-- File link error -->
+      <div v-if="linkError" class="text-[11px] text-red-400 mb-1 px-1">
+        {{ linkError }}
       </div>
 
       <!-- Linked Context List -->

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -64,6 +64,12 @@ function showLinkError(msg: string) {
   }, 4000);
 }
 
+function extractErrorMessage(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return "Failed to link file — binary or unreadable files cannot be used as context.";
+}
+
 async function pickContext(isFolder: boolean) {
   if (!activeConvId.value) return;
 
@@ -92,13 +98,7 @@ async function pickContext(isFolder: boolean) {
     });
   } catch (err) {
     console.error("Failed to link context:", err);
-    showLinkError(
-      typeof err === "string"
-        ? err
-        : err instanceof Error
-          ? err.message
-          : "Failed to link file — binary or unreadable files cannot be used as context.",
-    );
+    showLinkError(extractErrorMessage(err));
   } finally {
     isLinking.value = false;
   }
@@ -322,13 +322,7 @@ const {
       });
     } catch (err) {
       console.error("Failed to link dropped file:", err);
-      showLinkError(
-        typeof err === "string"
-          ? err
-          : err instanceof Error
-            ? err.message
-            : "Failed to link file — binary or unreadable files cannot be used as context.",
-      );
+      showLinkError(extractErrorMessage(err));
     } finally {
       isLinking.value = false;
     }

--- a/src/components/chat/CodeBlock.test.ts
+++ b/src/components/chat/CodeBlock.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import { nextTick } from "vue";
 
@@ -56,5 +56,26 @@ describe("CodeBlock — collapse behavior", () => {
     await nextTick();
     // 50 total - 25 shown = 25 hidden
     expect(wrapper.find(".collapse-button").text()).toContain("25");
+  });
+});
+
+describe("CodeBlock — onBeforeUnmount cleanup", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("clears the pending highlight timeout on unmount so it does not fire after teardown", async () => {
+    vi.useFakeTimers();
+
+    const wrapper = mount(CodeBlock, {
+      props: { code: makeCode(5), language: "ts" },
+    });
+    await nextTick();
+
+    // Unmounting before the debounced highlight fires should not throw
+    expect(() => {
+      wrapper.unmount();
+      vi.advanceTimersByTime(500);
+    }).not.toThrow();
   });
 });

--- a/src/components/chat/CodeBlock.vue
+++ b/src/components/chat/CodeBlock.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted, computed } from "vue";
+import { ref, watch, onMounted, onBeforeUnmount, computed } from "vue";
 import { highlight } from "../../lib/markdown";
 import { useCopyToClipboard } from "../../composables/useCopyToClipboard";
 
@@ -118,6 +118,12 @@ watch([() => props.code, () => props.language], updateHighlight, {
   immediate: false,
 });
 onMounted(() => updateHighlight());
+onBeforeUnmount(() => {
+  if (highlightTimeout) {
+    clearTimeout(highlightTimeout);
+    highlightTimeout = null;
+  }
+});
 </script>
 
 <style scoped>

--- a/src/components/chat/input/AdvancedChatOptions.vue
+++ b/src/components/chat/input/AdvancedChatOptions.vue
@@ -294,7 +294,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, onMounted, onUnmounted } from "vue";
+import {
+  ref,
+  computed,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  onBeforeUnmount,
+} from "vue";
 import { useSettingsStore } from "../../../stores/settings";
 import type { ChatOptions, PresetOptions } from "../../../types/settings";
 import SettingsSlider from "../../settings/SettingsSlider.vue";
@@ -413,6 +420,14 @@ async function commitSave() {
   saveName.value = "";
 }
 
+let savedTimer: ReturnType<typeof setTimeout> | null = null;
+let errorTimer: ReturnType<typeof setTimeout> | null = null;
+
+onBeforeUnmount(() => {
+  if (savedTimer) clearTimeout(savedTimer);
+  if (errorTimer) clearTimeout(errorTimer);
+});
+
 async function handleSaveAsModelDefault() {
   if (!props.model || savingDefault.value) return;
   const effective = resolveCurrentOptions();
@@ -422,13 +437,13 @@ async function handleSaveAsModelDefault() {
   try {
     await saveAsModelDefault(props.model, effective);
     savedAsDefault.value = true;
-    setTimeout(() => {
+    savedTimer = setTimeout(() => {
       savedAsDefault.value = false;
     }, 2000);
   } catch (e) {
     console.error("[AdvancedChatOptions] set_model_defaults failed:", e);
     saveDefaultError.value = true;
-    setTimeout(() => {
+    errorTimer = setTimeout(() => {
       saveDefaultError.value = false;
     }, 3000);
   } finally {

--- a/src/composables/useAttachments.test.ts
+++ b/src/composables/useAttachments.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi } from "vitest";
 
-vi.mock("@tauri-apps/plugin-fs", () => ({
-  readFile: vi.fn(),
+const mockInvoke = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
 }));
 
 // jsdom doesn't implement createObjectURL — stub it with a counter so each call returns a unique URL
@@ -74,14 +75,15 @@ describe("useAttachments", () => {
 
   it("handleDroppedPaths attaches image paths as binary attachments", async () => {
     urlCounter = 0;
-    const { readFile } = await import("@tauri-apps/plugin-fs");
-    vi.mocked(readFile).mockResolvedValue(new Uint8Array([1, 2, 3]));
+    mockInvoke.mockResolvedValue([1, 2, 3]);
     const { useAttachments } = await import("./useAttachments");
     const { attachments, handleDroppedPaths } = useAttachments();
     await handleDroppedPaths(["/home/user/photo.png"]);
     expect(attachments.value).toHaveLength(1);
     expect(attachments.value[0].data).toBeInstanceOf(Uint8Array);
-    expect(readFile).toHaveBeenCalledWith("/home/user/photo.png");
+    expect(mockInvoke).toHaveBeenCalledWith("read_image_file", {
+      path: "/home/user/photo.png",
+    });
   });
 
   it("handleDroppedPaths calls onLinkFile for text file paths", async () => {
@@ -102,8 +104,7 @@ describe("useAttachments", () => {
   });
 
   it("handleDroppedPaths handles multiple files in one call", async () => {
-    const { readFile } = await import("@tauri-apps/plugin-fs");
-    vi.mocked(readFile).mockResolvedValue(new Uint8Array([1]));
+    mockInvoke.mockResolvedValue([1]);
     const onLinkFile = vi.fn().mockResolvedValue(undefined);
     const { useAttachments } = await import("./useAttachments");
     const { attachments, handleDroppedPaths } = useAttachments({ onLinkFile });

--- a/src/composables/useAttachments.ts
+++ b/src/composables/useAttachments.ts
@@ -76,9 +76,16 @@ export function useAttachments(options: AttachmentsOptions = {}) {
       paths.map(async (path) => {
         const ext = extOf(path);
         if (IMAGE_EXTS.has(ext)) {
-          const { readFile } = await import("@tauri-apps/plugin-fs");
-          const bytes = await readFile(path);
+          const { invoke } = await import("@tauri-apps/api/core");
           const name = path.split("/").pop() ?? "image";
+          let rawBytes: number[];
+          try {
+            rawBytes = await invoke<number[]>("read_image_file", { path });
+          } catch (e) {
+            console.warn(`Dropped image ${name} could not be read: ${e}`);
+            return;
+          }
+          const bytes = new Uint8Array(rawBytes);
           const file = new File([bytes], name, { type: mimeFromExt(ext) });
           const previewUrl = URL.createObjectURL(file);
           attachments.value.push({ file, previewUrl, data: bytes });

--- a/src/composables/useDraftManager.test.ts
+++ b/src/composables/useDraftManager.test.ts
@@ -206,8 +206,8 @@ describe("useDraftManager", () => {
       await saveDraftToDb("conv-1", draft);
 
       expect(invoke).toHaveBeenCalledWith("update_chat_draft", {
-        conversation_id: "conv-1",
-        draft_json: JSON.stringify(draft),
+        conversationId: "conv-1",
+        draftJson: JSON.stringify(draft),
       });
       expect(store.conversations[0].draft_json).toBe(JSON.stringify(draft));
     });
@@ -268,8 +268,8 @@ describe("useDraftManager", () => {
       expect(store.drafts["conv-clr"]).toBeUndefined();
       expect(store.conversations[0].draft_json).toBeNull();
       expect(invoke).toHaveBeenCalledWith("update_chat_draft", {
-        conversation_id: "conv-clr",
-        draft_json: null,
+        conversationId: "conv-clr",
+        draftJson: null,
       });
     });
 

--- a/src/composables/useDraftManager.ts
+++ b/src/composables/useDraftManager.ts
@@ -77,8 +77,8 @@ export function useDraftManager() {
     if (conversationId.startsWith(DRAFT_ID_PREFIX)) return;
     try {
       await invoke("update_chat_draft", {
-        conversation_id: conversationId,
-        draft_json: JSON.stringify(draft),
+        conversationId,
+        draftJson: JSON.stringify(draft),
       });
       const conv = store.conversations.find((c) => c.id === conversationId);
       if (conv) conv.draft_json = JSON.stringify(draft);
@@ -89,12 +89,13 @@ export function useDraftManager() {
 
   async function clearDraft(conversationId: string) {
     delete store.drafts[conversationId];
+    if (conversationId.startsWith(DRAFT_ID_PREFIX)) return;
     const conv = store.conversations.find((c) => c.id === conversationId);
     if (conv) conv.draft_json = null;
     try {
       await invoke("update_chat_draft", {
-        conversation_id: conversationId,
-        draft_json: null,
+        conversationId,
+        draftJson: null,
       });
     } catch (err) {
       console.warn("Failed to clear draft from DB", err);

--- a/src/composables/useStreamingEvents.ts
+++ b/src/composables/useStreamingEvents.ts
@@ -9,7 +9,6 @@ export function useStreamingEvents() {
 
   async function init() {
     if (chatStore._listenersInitialized) return;
-    chatStore._listenersInitialized = true;
 
     // Tear down any previous listener set before registering a new one.
     if (_streamingCleanup) {
@@ -128,8 +127,15 @@ export function useStreamingEvents() {
       },
     });
 
-    await listenersReady;
-    _streamingCleanup = cleanup;
+    try {
+      await listenersReady;
+      _streamingCleanup = cleanup;
+      chatStore._listenersInitialized = true;
+    } catch (e) {
+      _streamingCleanup = null;
+      cleanup();
+      throw e;
+    }
   }
 
   return { init };

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -263,6 +263,8 @@ export const useChatStore = defineStore("chat", {
           }),
         ]);
 
+        if (this.activeConversationId !== id) return;
+
         this.messages[id] = (rawMessages || []).map((m) => {
           let images: Uint8Array[] = [];
           try {
@@ -311,6 +313,9 @@ export const useChatStore = defineStore("chat", {
             };
           }),
         );
+
+        if (this.activeConversationId !== id) return;
+
         this.folderContexts[id] = populatedContexts;
       } catch (err) {
         console.warn("Could not load conversation data", err);

--- a/src/stores/hosts.ts
+++ b/src/stores/hosts.ts
@@ -9,6 +9,7 @@ export const useHostStore = defineStore("hosts", {
     activeHostId: null as string | null,
     isHostManagerOpen: false,
     listenersInitialized: false,
+    _unlisten: null as (() => void) | null,
   }),
   getters: {
     activeHost: (state) =>
@@ -65,20 +66,25 @@ export const useHostStore = defineStore("hosts", {
     },
     async initListeners() {
       if (this.listenersInitialized) return;
+      const unlisten = await listen<HostStatusChangePayload>(
+        "host:status-change",
+        (event) => {
+          const payload = event.payload;
+          const hostIndex = this.hosts.findIndex(
+            (h) => h.id === payload.host_id,
+          );
+          const host = this.hosts[hostIndex];
+          if (host) {
+            this.hosts[hostIndex] = {
+              ...host,
+              last_ping_status: payload.status,
+              last_ping_at: new Date().toISOString(),
+            };
+          }
+        },
+      );
+      this._unlisten = unlisten;
       this.listenersInitialized = true;
-
-      listen<HostStatusChangePayload>("host:status-change", (event) => {
-        const payload = event.payload;
-        const hostIndex = this.hosts.findIndex((h) => h.id === payload.host_id);
-        const host = this.hosts[hostIndex];
-        if (host) {
-          this.hosts[hostIndex] = {
-            ...host,
-            last_ping_status: payload.status,
-            last_ping_at: new Date().toISOString(),
-          };
-        }
-      });
     },
   },
 });

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -327,54 +327,45 @@ export const useModelStore = defineStore("models", {
       const unlistens: Array<() => void> = [];
       try {
         unlistens.push(
-          await listen<PullProgressPayload>("model:pull-progress", (event) => {
-            const payload = event.payload;
-            this.pulling[payload.model] = payload;
-          }),
-        );
-        unlistens.push(
-          await listen<{ model: string }>("model:pull-done", (event) => {
-            const payload = event.payload;
-            delete this.pulling[payload.model];
-            this.fetchModels();
-            this.fetchCapabilities(payload.model);
-          }),
-        );
-        unlistens.push(
-          await listen<CreateProgressPayload>(
-            "model:create-progress",
-            (event) => {
+          ...(await Promise.all([
+            listen<PullProgressPayload>("model:pull-progress", (event) => {
+              const payload = event.payload;
+              this.pulling[payload.model] = payload;
+            }),
+            listen<{ model: string }>("model:pull-done", (event) => {
+              const payload = event.payload;
+              delete this.pulling[payload.model];
+              this.fetchModels();
+              this.fetchCapabilities(payload.model);
+            }),
+            listen<CreateProgressPayload>("model:create-progress", (event) => {
               const { model, status } = event.payload;
               if (this.creating[model]) {
                 this.creating[model].status = status;
                 this.creating[model].logLines.push(status);
               }
-            },
-          ),
-        );
-        unlistens.push(
-          await listen<CreateDonePayload>("model:create-done", (event) => {
-            const { model } = event.payload;
-            if (this.creating[model]) {
-              this.creating[model].phase = "done";
-            }
-            this.fetchModels();
-          }),
-        );
-        unlistens.push(
-          await listen<CreateErrorPayload>("model:create-error", (event) => {
-            const { model, error, cancelled } = event.payload;
-            if (this.creating[model]) {
-              if (cancelled) {
-                // No reason to keep cancelled state in memory — delete immediately.
-                // CreateModelPage captures the phase locally before this fires.
-                delete this.creating[model];
-              } else {
-                this.creating[model].phase = "error";
-                this.creating[model].error = error;
+            }),
+            listen<CreateDonePayload>("model:create-done", (event) => {
+              const { model } = event.payload;
+              if (this.creating[model]) {
+                this.creating[model].phase = "done";
               }
-            }
-          }),
+              this.fetchModels();
+            }),
+            listen<CreateErrorPayload>("model:create-error", (event) => {
+              const { model, error, cancelled } = event.payload;
+              if (this.creating[model]) {
+                if (cancelled) {
+                  // No reason to keep cancelled state in memory — delete immediately.
+                  // CreateModelPage captures the phase locally before this fires.
+                  delete this.creating[model];
+                } else {
+                  this.creating[model].phase = "error";
+                  this.creating[model].error = error;
+                }
+              }
+            }),
+          ])),
         );
         this._unlisten = unlistens;
         this.listenersInitialized = true;

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -54,6 +54,7 @@ export const useModelStore = defineStore("models", {
     isLoading: false,
     error: null as string | null,
     listenersInitialized: false,
+    _unlisten: [] as Array<() => void>,
     capabilities: {} as Record<string, ModelCapabilities>,
     modelUserData: {} as Record<string, ModelUserData>,
     // Library search state
@@ -61,6 +62,7 @@ export const useModelStore = defineStore("models", {
     searchQuery: "",
     isSearching: false,
     _searchTimer: null as ReturnType<typeof setTimeout> | null,
+    _searchVersion: 0,
     // Details view state
     selectedModel: null as LibraryModel | null,
     selectedModelTags: [] as LibraryTag[],
@@ -291,17 +293,26 @@ export const useModelStore = defineStore("models", {
         return;
       }
       this.isSearching = true;
+      this._searchVersion++;
+      const version = this._searchVersion;
       this._searchTimer = setTimeout(async () => {
         try {
-          this.libraryResults = await invoke<LibraryModel[]>(
+          const results = await invoke<LibraryModel[]>(
             "search_ollama_library",
             { query: q },
           );
+          if (version === this._searchVersion) {
+            this.libraryResults = results;
+          }
         } catch (err) {
-          console.error("Library search failed:", err);
-          this.libraryResults = [];
+          if (version === this._searchVersion) {
+            console.error("Library search failed:", err);
+            this.libraryResults = [];
+          }
         } finally {
-          this.isSearching = false;
+          if (version === this._searchVersion) {
+            this.isSearching = false;
+          }
         }
       }, 300);
     },
@@ -313,45 +324,65 @@ export const useModelStore = defineStore("models", {
     },
     async initListeners() {
       if (this.listenersInitialized) return;
-      this.listenersInitialized = true;
-
-      await listen<PullProgressPayload>("model:pull-progress", (event) => {
-        const payload = event.payload;
-        this.pulling[payload.model] = payload;
-      });
-      await listen<{ model: string }>("model:pull-done", (event) => {
-        const payload = event.payload;
-        delete this.pulling[payload.model];
-        this.fetchModels();
-        this.fetchCapabilities(payload.model);
-      });
-      await listen<CreateProgressPayload>("model:create-progress", (event) => {
-        const { model, status } = event.payload;
-        if (this.creating[model]) {
-          this.creating[model].status = status;
-          this.creating[model].logLines.push(status);
-        }
-      });
-      await listen<CreateDonePayload>("model:create-done", (event) => {
-        const { model } = event.payload;
-        if (this.creating[model]) {
-          this.creating[model].phase = "done";
-        }
-        this.fetchModels();
-      });
-      await listen<CreateErrorPayload>("model:create-error", (event) => {
-        const { model, error, cancelled } = event.payload;
-        if (this.creating[model]) {
-          if (cancelled) {
-            // No reason to keep cancelled state in memory — delete immediately.
-            // CreateModelPage captures the phase locally before this fires.
-            delete this.creating[model];
-          } else {
-            this.creating[model].phase = "error";
-            this.creating[model].error = error;
-          }
-        }
-      });
+      const unlistens: Array<() => void> = [];
+      try {
+        unlistens.push(
+          await listen<PullProgressPayload>("model:pull-progress", (event) => {
+            const payload = event.payload;
+            this.pulling[payload.model] = payload;
+          }),
+        );
+        unlistens.push(
+          await listen<{ model: string }>("model:pull-done", (event) => {
+            const payload = event.payload;
+            delete this.pulling[payload.model];
+            this.fetchModels();
+            this.fetchCapabilities(payload.model);
+          }),
+        );
+        unlistens.push(
+          await listen<CreateProgressPayload>(
+            "model:create-progress",
+            (event) => {
+              const { model, status } = event.payload;
+              if (this.creating[model]) {
+                this.creating[model].status = status;
+                this.creating[model].logLines.push(status);
+              }
+            },
+          ),
+        );
+        unlistens.push(
+          await listen<CreateDonePayload>("model:create-done", (event) => {
+            const { model } = event.payload;
+            if (this.creating[model]) {
+              this.creating[model].phase = "done";
+            }
+            this.fetchModels();
+          }),
+        );
+        unlistens.push(
+          await listen<CreateErrorPayload>("model:create-error", (event) => {
+            const { model, error, cancelled } = event.payload;
+            if (this.creating[model]) {
+              if (cancelled) {
+                // No reason to keep cancelled state in memory — delete immediately.
+                // CreateModelPage captures the phase locally before this fires.
+                delete this.creating[model];
+              } else {
+                this.creating[model].phase = "error";
+                this.creating[model].error = error;
+              }
+            }
+          }),
+        );
+        this._unlisten = unlistens;
+        this.listenersInitialized = true;
+      } catch (e) {
+        unlistens.forEach((fn) => fn());
+        // listenersInitialized stays false — retry is possible
+        throw e;
+      }
     },
 
     clearCreateState(name: string) {


### PR DESCRIPTION
## Summary

- Draft message input now persists to the database — IPC call was using snake_case keys (`conversation_id`, `draft_json`) instead of Tauri v2 camelCase convention
- Clearing a draft on an unsaved conversation no longer emits "Conversation not found" warnings — `clearDraft` was missing the `DRAFT_ID_PREFIX` guard that `saveDraftToDb` already had
- Linked file context (text files via "Link File Context") now reaches the LLM — `read_folder_context` used `if let Ok(...)` on `read_to_string`, silently returning empty content for non-UTF-8 or permission-denied files; now uses `fs::read()` + `from_utf8_lossy()`
- File link errors in chat input now show the real backend error message — Tauri errors are plain strings, not `Error` instances, so `err instanceof Error` always fell through to the generic fallback
- Tauri capability narrowed from broad `fs:allow-read-file` to a scoped `read_image_file` command with extension allowlist and 20 MB guard; unused `opener:allow-open-path` removed
- Additional cleanup: cancel_tx leak in orchestrator, `let_underscore_future` clippy lint, streaming listener flag ordering, stale navigation guard in `loadConversation`, listener rollback and search version counter in `models.ts`, `no-useless-catch` in `hosts.ts`, timer cleanup in `CodeBlock.vue` and `AdvancedChatOptions.vue`

## Test plan

- [ ] Type a message in a new or existing chat, navigate away — verify draft is restored on return
- [ ] Attach a text file via "Link File Context", send a message — verify the model sees the file content
- [ ] Attach an unsupported or binary file — verify the actual error is shown (not the generic fallback)
- [ ] Press Stop mid-generation — verify cancel_tx is cleaned up (no lock contention on next message)
- [ ] Attempt to drop a non-image file onto chat — confirm extension rejection works correctly
- [ ] Run `pnpm test` and `cargo test` — all suites green

Closes #113