### PR TITLE
fix(ci): close pipeline gaps — clippy coverage, docs PR build, release preflight, SonarCloud annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [main, develop, release/*, hotfix/*]
+    tags: ['v*']
   pull_request:
     branches: [main, develop, release/*, hotfix/*]
 
@@ -229,7 +230,7 @@ jobs:
 
       - name: Cargo clippy
         if: needs.changes.outputs.rust == 'true'
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
         working-directory: src-tauri
 
       - name: Setup pnpm
@@ -297,7 +298,7 @@ jobs:
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -531,7 +532,12 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        env:
+          OLLAMA_VERSION: "0.6.5"
+        run: |
+          curl -fsSL "https://github.com/ollama/ollama/releases/download/v${OLLAMA_VERSION}/ollama-linux-amd64" \
+            -o /usr/local/bin/ollama
+          chmod +x /usr/local/bin/ollama
 
       - name: Start Ollama and pull test model
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:
@@ -45,6 +50,7 @@ jobs:
     name: Deploy to gh-pages
     runs-on: ubuntu-22.04
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
     concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,25 @@ jobs:
           fetch-depth: 0
 
       # ------------------------------------------------------------------ #
+      # 1b. Version consistency preflight                                   #
+      # ------------------------------------------------------------------ #
+      - name: Verify version consistency
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(jq -r '.version' package.json)
+          CARGO_VERSION=$(grep '^version = ' src-tauri/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TAURI_VERSION=$(jq -r '.version' src-tauri/tauri.conf.json)
+          CHANGELOG_MATCH=$(grep "^## \[${TAG}\]" CHANGELOG.md || echo "")
+          FAIL=0
+          [ "$PKG_VERSION"   != "$TAG" ] && echo "ERROR: package.json version (${PKG_VERSION}) != tag (${TAG})"       && FAIL=1
+          [ "$CARGO_VERSION" != "$TAG" ] && echo "ERROR: Cargo.toml version (${CARGO_VERSION}) != tag (${TAG})"       && FAIL=1
+          [ "$TAURI_VERSION" != "$TAG" ] && echo "ERROR: tauri.conf.json version (${TAURI_VERSION}) != tag (${TAG})"  && FAIL=1
+          [ -z "$CHANGELOG_MATCH"      ] && echo "ERROR: CHANGELOG.md has no entry for [${TAG}]"                      && FAIL=1
+          [ $FAIL -eq 0 ] && echo "All version sources match tag ${TAG}."
+          exit $FAIL
+
+      # ------------------------------------------------------------------ #
       # 2. Rust stable with Swatinem cache                                  #
       # ------------------------------------------------------------------ #
       - name: Install Rust stable
@@ -276,6 +295,8 @@ jobs:
 
       - name: Generate .SRCINFO via Arch Linux container
         if: steps.guard.outputs.run == 'true'
+        # TODO: pin archlinux/archlinux:base-devel by digest for reproducible builds
+        # e.g. archlinux/archlinux@sha256:<digest>  (run: docker pull archlinux/archlinux:base-devel && docker inspect --format='{{index .RepoDigests 0}}')
         run: |
           docker run --rm \
             -v "$(pwd)/packaging/aur:/pkg" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### CI/CD
+- `cargo clippy` now runs with `--all-targets --all-features` to catch cfg-gated lint failures that were silently skipped
+- CI triggers on `v*` tag pushes so the release ci-gate finds check-runs on the tagged commit instead of polling until timeout
+- `docs.yml` now builds VitePress on pull requests targeting docs; deploy is guarded to push-to-main only
+- `release-linux` job verifies version consistency across `package.json`, `Cargo.toml`, `tauri.conf.json`, and `CHANGELOG.md` before building
+- Ollama install in the integration job replaced with a pinned binary download (v0.6.5) instead of an unpinned `curl | sh` script
+- `test-and-coverage` job upgraded from `pull-requests: read` to `pull-requests: write` so SonarCloud can post inline PR annotations
+
 ### Fixed
 - Cancelling generation (Stop button or Esc) no longer emits `chat:done`, persists a partial message to the database, or triggers a completion notification; partial content is preserved in-session via the new `chat:cancelled` event
 - Esc key now correctly clears the streaming indicator (previously `isStreaming` stayed true after pressing Esc)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,6 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-### CI/CD
-- `cargo clippy` now runs with `--all-targets --all-features` to catch cfg-gated lint failures that were silently skipped
-- CI triggers on `v*` tag pushes so the release ci-gate finds check-runs on the tagged commit instead of polling until timeout
-- `docs.yml` now builds VitePress on pull requests targeting docs; deploy is guarded to push-to-main only
-- `release-linux` job verifies version consistency across `package.json`, `Cargo.toml`, `tauri.conf.json`, and `CHANGELOG.md` before building
-- Ollama install in the integration job replaced with a pinned binary download (v0.6.5) instead of an unpinned `curl | sh` script
-- `test-and-coverage` job upgraded from `pull-requests: read` to `pull-requests: write` so SonarCloud can post inline PR annotations
-
 ### Fixed
 - Cancelling generation (Stop button or Esc) no longer emits `chat:done`, persists a partial message to the database, or triggers a completion notification; partial content is preserved in-session via the new `chat:cancelled` event
 - Esc key now correctly clears the streaming indicator (previously `isStreaming` stayed true after pressing Esc)


### PR DESCRIPTION
## Summary

Closes #115

- `cargo clippy` now runs `--all-targets --all-features` so cfg-gated code paths (e.g. `#[cfg(test)]`) are linted in CI
- CI triggers on `v*` tag pushes so the release `ci-gate` job finds check-runs on the tagged commit instead of timing out after 30 min
- `docs.yml` now runs `pnpm docs:build` on pull requests that touch `docs/**`; the deploy job is guarded to push-to-main only
- `release-linux` job verifies that `package.json`, `Cargo.toml`, `tauri.conf.json`, and `CHANGELOG.md` all match the tag before building artifacts
- Ollama integration install replaced: `curl | sh` from live website → pinned binary download from GitHub releases (`v0.6.5`)
- `test-and-coverage` job `pull-requests` permission raised from `read` → `write` so SonarCloud can post inline annotations on PRs

## Test Plan

- [ ] Verify CI run triggered by this PR shows `cargo clippy --all-targets --all-features` in the Build Check job
- [ ] Verify SonarCloud posts inline PR annotations (not just the Quality Gate summary comment)
- [ ] Verify docs build step appears in CI for this PR (docs files not changed here, but confirm workflow parses correctly)
- [ ] Confirm no regressions in other CI jobs