### PR TITLE
release: v1.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,7 +267,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch origin "${BASE_REF}" --depth=1
+          git fetch origin "${BASE_REF}"
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
           if echo "$CHANGED" | grep -Fxq "CHANGELOG.md"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [1.2.1] - 2026-05-04
+
 ### Security
 - API key is now restricted to `https://api.ollama.com` only: `is_cloud_host` requires HTTPS scheme, preventing the key from being attached to plaintext HTTP connections; `validate_api_key` rejects any host that is not the cloud endpoint before reading the key from the keyring
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alpaka-desktop",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Native Linux desktop client for Ollama",
   "private": true,
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "alpaka-desktop"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alpaka-desktop"
-version = "1.2.0"
+version = "1.2.1"
 description = "Native desktop client for Ollama"
 authors = ["nikoteressi@gmail.com"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "alpaka-desktop",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "identifier": "io.alpaka.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- Bumps version to **1.2.1** across `package.json`, `Cargo.toml`, `tauri.conf.json`, and `Cargo.lock`
- Promotes `[Unreleased]` to `[1.2.1] - 2026-05-04` in `CHANGELOG.md`
- Fixes the CI CHANGELOG check that caused the hotfix PR (#110) to fail: `git fetch origin "${BASE_REF}" --depth=1` used a shallow fetch that prevented the three-dot diff from finding the merge base when the hotfix branch forked from an older commit, making CHANGELOG.md appear unchanged

## What goes into 1.2.1

- **Security**: API key restricted to `https://api.ollama.com` only (hotfix from #110)
- **Changed**: Removed unused dependencies

## Test plan

- [ ] CI passes on this PR (CHANGELOG check should now work correctly)
- [ ] After merge, push tag `v1.2.1` to trigger the release workflow
- [ ] Verify release workflow creates the GitHub Release with AppImage and .deb artifacts