### PR TITLE
feat(G-05): GPU layer offloading configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ dist-ssr
 
 # Claude Code / AI tool runtime dirs
 .claude
-CLAUDE.md
 .superpowers/
 .playwright-mcp/
 .playwright-mcp.worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ dist-ssr
 
 # Claude Code / AI tool runtime dirs
 .claude
+CLAUDE.md
 .superpowers/
 .playwright-mcp/
 .playwright-mcp.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- G-05: GPU layer offloading configuration — Settings → Engine tab now has a "GPU Layers" input (`num_gpu`). Set to `-1` for auto (all layers), `0` for CPU-only, or any positive integer for partial offloading. Current GPU/VRAM is shown as a guide. The G-01 hardware display on the Models page reflects the configured offloading mode.
 - HTTP/SOCKS5 proxy support — configure a proxy URL, optional username, and password (stored in the system keyring) in Settings → Connection; a "Test proxy" button verifies end-to-end connectivity
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -210,6 +210,7 @@ alpaka-desktop/
 │   │   ├── settings/
 │   │   │   ├── AccountSettings.vue   # OAuth signin + API key panel
 │   │   │   ├── ApiKeyPanel.vue
+│   │   │   ├── GpuLayersSettings.vue # num_gpu input + detect_hardware summary (Settings → Engine)
 │   │   │   ├── HostSettings.vue      # Host CRUD lives here, not in HostManager.vue
 │   │   │   ├── ProxySettings.vue     # HTTP/SOCKS5 proxy config (URL, username, keyring password)
 │   │   │   ├── ModelPathSettings.vue

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -133,7 +133,7 @@ values fall back outward (`ChatOptions::merge_with_fallback` in `ollama/types.rs
 | G-02 | **Multi-GPU support** | P0 | ✅ | Inherited from Ollama's multi-GPU scheduling; no app-level work required |
 | G-03 | **CPU fallback indicator** | P0 | ❌ | No dedicated "running on CPU" indicator in the UI |
 | G-04 | **Per-message performance metrics** | P1 | ✅ | Tokens/sec, TTFT, total / load / prompt-eval / eval duration, seed, prompt_tokens — stored per message and rendered in `StatsBlock.vue` |
-| G-05 | **GPU layer configuration** | P1 | 🔲 Backlog | `num_gpu` layers for partial offloading |
+| G-05 | **GPU layer configuration** | P1 | ✅ | `num_gpu` layers for partial offloading. Settings → Engine tab (`GpuLayersSettings.vue`): numeric input (-1 = auto, 0 = CPU only, N = partial). VRAM shown as guide via `detect_hardware`. G-01 GPU card in Models → Engine tab shows offloading badge when `num_gpu` ≠ -1. Validated server-side in `validate_chat_options`. |
 
 ### 2.7 Networking, Hosts & Sharing
 

--- a/src-tauri/src/commands/model_settings.rs
+++ b/src-tauri/src/commands/model_settings.rs
@@ -78,6 +78,13 @@ pub(crate) fn validate_chat_options(opts: &ChatOptions) -> Result<(), AppError> 
             ));
         }
     }
+    if let Some(ng) = opts.num_gpu {
+        if ng != -1 && !(0..=999).contains(&ng) {
+            return Err(AppError::Validation(
+                "num_gpu must be -1 (auto) or in range [0, 999]".into(),
+            ));
+        }
+    }
     if let Some(ref stops) = opts.stop {
         if stops.len() > 4 {
             return Err(AppError::Validation(
@@ -91,4 +98,61 @@ pub(crate) fn validate_chat_options(opts: &ChatOptions) -> Result<(), AppError> 
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ollama::types::ChatOptions;
+
+    #[test]
+    fn test_validate_num_gpu_auto_sentinel_accepted() {
+        let opts = ChatOptions {
+            num_gpu: Some(-1),
+            ..Default::default()
+        };
+        assert!(validate_chat_options(&opts).is_ok());
+    }
+
+    #[test]
+    fn test_validate_num_gpu_zero_cpu_only_accepted() {
+        let opts = ChatOptions {
+            num_gpu: Some(0),
+            ..Default::default()
+        };
+        assert!(validate_chat_options(&opts).is_ok());
+    }
+
+    #[test]
+    fn test_validate_num_gpu_valid_range_accepted() {
+        let opts = ChatOptions {
+            num_gpu: Some(999),
+            ..Default::default()
+        };
+        assert!(validate_chat_options(&opts).is_ok());
+    }
+
+    #[test]
+    fn test_validate_num_gpu_out_of_range_rejected() {
+        let opts = ChatOptions {
+            num_gpu: Some(1000),
+            ..Default::default()
+        };
+        assert!(validate_chat_options(&opts).is_err());
+    }
+
+    #[test]
+    fn test_validate_num_gpu_negative_non_sentinel_rejected() {
+        let opts = ChatOptions {
+            num_gpu: Some(-2),
+            ..Default::default()
+        };
+        assert!(validate_chat_options(&opts).is_err());
+    }
+
+    #[test]
+    fn test_validate_num_gpu_none_accepted() {
+        let opts = ChatOptions::default();
+        assert!(validate_chat_options(&opts).is_ok());
+    }
 }

--- a/src-tauri/src/ollama/types.rs
+++ b/src-tauri/src/ollama/types.rs
@@ -94,6 +94,8 @@ pub struct ChatOptions {
     pub mirostat_tau: Option<f32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mirostat_eta: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub num_gpu: Option<i32>,
 }
 
 impl ChatOptions {
@@ -111,6 +113,7 @@ impl ChatOptions {
             mirostat: self.mirostat.or(fallback.mirostat),
             mirostat_tau: self.mirostat_tau.or(fallback.mirostat_tau),
             mirostat_eta: self.mirostat_eta.or(fallback.mirostat_eta),
+            num_gpu: self.num_gpu.or(fallback.num_gpu),
         }
     }
 }
@@ -287,5 +290,57 @@ mod tests {
         }"#;
         let resp: StreamResponse = serde_json::from_str(json).unwrap();
         assert!(resp.message.thinking.is_none());
+    }
+
+    #[test]
+    fn test_num_gpu_serialized_when_set() {
+        let opts = ChatOptions {
+            num_gpu: Some(20),
+            ..Default::default()
+        };
+        let val = serde_json::to_value(&opts).unwrap();
+        assert_eq!(val["num_gpu"], 20);
+    }
+
+    #[test]
+    fn test_num_gpu_omitted_when_none() {
+        let opts = ChatOptions::default();
+        let val = serde_json::to_value(&opts).unwrap();
+        assert!(val.get("num_gpu").is_none());
+    }
+
+    #[test]
+    fn test_num_gpu_merge_primary_wins() {
+        let primary = ChatOptions {
+            num_gpu: Some(10),
+            ..Default::default()
+        };
+        let fallback = ChatOptions {
+            num_gpu: Some(30),
+            ..Default::default()
+        };
+        let merged = primary.merge_with_fallback(&fallback);
+        assert_eq!(merged.num_gpu, Some(10));
+    }
+
+    #[test]
+    fn test_num_gpu_merge_fallback_fills() {
+        let primary = ChatOptions::default();
+        let fallback = ChatOptions {
+            num_gpu: Some(20),
+            ..Default::default()
+        };
+        let merged = primary.merge_with_fallback(&fallback);
+        assert_eq!(merged.num_gpu, Some(20));
+    }
+
+    #[test]
+    fn test_num_gpu_negative_one_serialized() {
+        let opts = ChatOptions {
+            num_gpu: Some(-1),
+            ..Default::default()
+        };
+        let val = serde_json::to_value(&opts).unwrap();
+        assert_eq!(val["num_gpu"], -1);
     }
 }

--- a/src/components/settings/GpuLayersSettings.spec.ts
+++ b/src/components/settings/GpuLayersSettings.spec.ts
@@ -139,4 +139,19 @@ describe("GpuLayersSettings", () => {
 
     expect(spy).toHaveBeenCalledWith({ num_gpu: -1 });
   });
+
+  it("clamps input value to maximum of 999", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const store = useSettingsStore();
+    const spy = vi.spyOn(store, "updateChatOptions").mockResolvedValue();
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find("input[type='number']");
+    await input.setValue("9999");
+    await input.trigger("change");
+
+    expect(spy).toHaveBeenCalledWith({ num_gpu: 999 });
+  });
 });

--- a/src/components/settings/GpuLayersSettings.spec.ts
+++ b/src/components/settings/GpuLayersSettings.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { setActivePinia, createPinia } from "pinia";
+import GpuLayersSettings from "./GpuLayersSettings.vue";
+import { useSettingsStore } from "../../stores/settings";
+
+const mockInvoke = vi.fn();
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (cmd: string, args?: Record<string, unknown>) =>
+    mockInvoke(cmd, args),
+}));
+
+function mountComponent() {
+  return mount(GpuLayersSettings);
+}
+
+describe("GpuLayersSettings", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockReset();
+    mockInvoke.mockResolvedValue({
+      ram_mb: 16384,
+      gpu_name: "RX 6800",
+      vram_mb: 16384,
+    });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the GPU Layers heading", async () => {
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain("GPU Layers");
+  });
+
+  it("calls detect_hardware on mount", async () => {
+    mountComponent();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockInvoke).toHaveBeenCalledWith("detect_hardware", undefined);
+  });
+
+  it("shows GPU name after hardware detection", async () => {
+    const wrapper = mountComponent();
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain("RX 6800");
+  });
+
+  it("shows VRAM info after hardware detection", async () => {
+    const wrapper = mountComponent();
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain("16.0 GB VRAM");
+  });
+
+  it("shows 'No GPU detected' when gpu_name is absent", async () => {
+    mockInvoke.mockResolvedValue({
+      ram_mb: 16384,
+      gpu_name: undefined,
+      vram_mb: undefined,
+    });
+    const wrapper = mountComponent();
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain("No GPU detected");
+  });
+
+  it("number input reflects store num_gpu value", async () => {
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, num_gpu: 20 };
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find("input[type='number']");
+    expect((input.element as HTMLInputElement).value).toBe("20");
+  });
+
+  it("displays 'All layers (auto)' when num_gpu is -1", async () => {
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, num_gpu: -1 };
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("All layers");
+  });
+
+  it("displays 'CPU only' when num_gpu is 0", async () => {
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, num_gpu: 0 };
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("CPU only");
+  });
+
+  it("displays 'N layers on GPU' for positive num_gpu", async () => {
+    const store = useSettingsStore();
+    store.chatOptions = { ...store.chatOptions, num_gpu: 15 };
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("15 layers on GPU");
+  });
+
+  it("changing input calls updateChatOptions", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const store = useSettingsStore();
+    const spy = vi.spyOn(store, "updateChatOptions").mockResolvedValue();
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find("input[type='number']");
+    await input.setValue("10");
+    await input.trigger("change");
+
+    expect(spy).toHaveBeenCalledWith({ num_gpu: 10 });
+  });
+
+  it("clamps input value to minimum of -1", async () => {
+    mockInvoke.mockResolvedValue(undefined);
+    const store = useSettingsStore();
+    const spy = vi.spyOn(store, "updateChatOptions").mockResolvedValue();
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find("input[type='number']");
+    await input.setValue("-5");
+    await input.trigger("change");
+
+    expect(spy).toHaveBeenCalledWith({ num_gpu: -1 });
+  });
+});

--- a/src/components/settings/GpuLayersSettings.vue
+++ b/src/components/settings/GpuLayersSettings.vue
@@ -65,8 +65,19 @@ function onNumGpuChange(e: Event) {
 onMounted(async () => {
   try {
     hardware.value = await invoke<HardwareInfo>("detect_hardware");
-  } catch {
-    // non-fatal: hardware detection is best-effort
+  } catch (e) {
+    console.warn("Hardware detection failed:", e);
   }
 });
 </script>
+
+<style scoped>
+.settings-card {
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+}
+</style>

--- a/src/components/settings/GpuLayersSettings.vue
+++ b/src/components/settings/GpuLayersSettings.vue
@@ -58,7 +58,9 @@ const layerLabel = computed(() => {
 function onNumGpuChange(e: Event) {
   const raw = (e.target as HTMLInputElement).value;
   const parsed = Number.parseInt(raw, 10);
-  const clamped = Number.isNaN(parsed) ? -1 : Math.max(-1, parsed);
+  const clamped = Number.isNaN(parsed)
+    ? -1
+    : Math.max(-1, Math.min(999, parsed));
   settingsStore.updateChatOptions({ num_gpu: clamped });
 }
 

--- a/src/components/settings/GpuLayersSettings.vue
+++ b/src/components/settings/GpuLayersSettings.vue
@@ -1,0 +1,72 @@
+<template>
+  <div class="settings-card gap-3">
+    <div>
+      <p class="text-[13.5px] font-bold text-[var(--text)]">GPU Layers</p>
+      <p class="text-[12px] text-[var(--text-dim)] mt-0.5">
+        Number of model layers to offload to the GPU.
+        <span class="font-mono">-1</span> = all layers (auto),
+        <span class="font-mono">0</span> = CPU only.
+      </p>
+    </div>
+
+    <!-- Hardware summary -->
+    <div
+      class="flex items-center gap-2 px-3 py-2 rounded-lg bg-[var(--bg-base)] border border-[var(--border-subtle)] text-[11.5px]"
+    >
+      <span v-if="hardware?.gpu_name" class="text-[var(--text)] font-medium">
+        {{ hardware.gpu_name }}
+      </span>
+      <span v-else class="text-[var(--text-dim)]">No GPU detected</span>
+
+      <span v-if="hardware?.vram_mb" class="text-[var(--accent)]">
+        · {{ (hardware.vram_mb / 1024).toFixed(1) }} GB VRAM
+      </span>
+    </div>
+
+    <!-- Input row -->
+    <div class="flex items-center gap-3">
+      <input
+        type="number"
+        :value="settingsStore.chatOptions.num_gpu ?? -1"
+        min="-1"
+        max="999"
+        step="1"
+        @change="onNumGpuChange"
+        class="w-28 bg-[var(--bg-input)] border border-[var(--border)] focus:border-[var(--accent)] text-[var(--text)] rounded-lg px-3 py-1.5 text-[12px] outline-none transition-colors font-mono"
+      />
+      <span class="text-[12px] text-[var(--text-dim)]">{{ layerLabel }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { useSettingsStore } from "../../stores/settings";
+import type { HardwareInfo } from "../../types/models";
+
+const settingsStore = useSettingsStore();
+const hardware = ref<HardwareInfo | null>(null);
+
+const layerLabel = computed(() => {
+  const v = settingsStore.chatOptions.num_gpu ?? -1;
+  if (v === -1) return "All layers (auto)";
+  if (v === 0) return "CPU only — no GPU offloading";
+  return `${v} layers on GPU`;
+});
+
+function onNumGpuChange(e: Event) {
+  const raw = (e.target as HTMLInputElement).value;
+  const parsed = Number.parseInt(raw, 10);
+  const clamped = Number.isNaN(parsed) ? -1 : Math.max(-1, parsed);
+  settingsStore.updateChatOptions({ num_gpu: clamped });
+}
+
+onMounted(async () => {
+  try {
+    hardware.value = await invoke<HardwareInfo>("detect_hardware");
+  } catch {
+    // non-fatal: hardware detection is best-effort
+  }
+});
+</script>

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -75,6 +75,7 @@ const DEFAULT_CHAT_OPTIONS: SettingsState["chatOptions"] = {
   mirostat: 0,
   mirostat_tau: 5,
   mirostat_eta: 0.1,
+  num_gpu: -1,
 };
 
 const getInitialState = (): SettingsState => ({

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -12,6 +12,7 @@ export interface ChatOptions {
   mirostat?: 0 | 1 | 2;
   mirostat_tau?: number;
   mirostat_eta?: number;
+  num_gpu?: number;
 }
 
 export type PresetOptions = Required<

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -525,10 +525,13 @@
                         Offloading: CPU only
                       </p>
                       <p
-                        v-else-if="(settingsStore.chatOptions.num_gpu ?? -1) > 0"
+                        v-else-if="
+                          (settingsStore.chatOptions.num_gpu ?? -1) > 0
+                        "
                         class="text-[10px] text-[var(--text-dim)] mt-1"
                       >
-                        Offloading: {{ settingsStore.chatOptions.num_gpu }} layers
+                        Offloading:
+                        {{ settingsStore.chatOptions.num_gpu }} layers
                       </p>
                     </div>
                     <div

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -518,6 +518,18 @@
                             : "No VRAM detected"
                         }}
                       </p>
+                      <p
+                        v-if="settingsStore.chatOptions.num_gpu === 0"
+                        class="text-[10px] text-[var(--text-dim)] mt-1"
+                      >
+                        Offloading: CPU only
+                      </p>
+                      <p
+                        v-else-if="(settingsStore.chatOptions.num_gpu ?? -1) > 0"
+                        class="text-[10px] text-[var(--text-dim)] mt-1"
+                      >
+                        Offloading: {{ settingsStore.chatOptions.num_gpu }} layers
+                      </p>
                     </div>
                     <div
                       class="bg-[var(--bg-base)] p-3 rounded-lg border border-[var(--border-subtle)]"
@@ -620,6 +632,7 @@ import LibraryBrowser from "../components/models/LibraryBrowser.vue";
 import CloudTagSelector from "../components/models/CloudTagSelector.vue";
 import CreateModelPage from "../components/models/CreateModelPage.vue";
 import { useModelStore, modelMatchesTag } from "../stores/models";
+import { useSettingsStore } from "../stores/settings";
 import { invoke } from "@tauri-apps/api/core";
 import { useAppOrchestration } from "../composables/useAppOrchestration";
 import { useConfirmationModal } from "../composables/useConfirmationModal";
@@ -636,6 +649,7 @@ import {
 
 const modelStore = useModelStore();
 const { selectedModel } = storeToRefs(modelStore);
+const settingsStore = useSettingsStore();
 
 const selectedLocalModel = ref<Model | null>(null);
 

--- a/src/views/SettingsPage.vue
+++ b/src/views/SettingsPage.vue
@@ -206,6 +206,8 @@
           >
             <ModelPathSettings />
 
+            <GpuLayersSettings />
+
             <SettingsRow icon="layout">
               <template #label>Context length</template>
               <template #subtitle
@@ -479,6 +481,7 @@ import AccountSettings from "../components/settings/AccountSettings.vue";
 import HostSettings from "../components/settings/HostSettings.vue";
 import ProxySettings from "../components/settings/ProxySettings.vue";
 import ModelPathSettings from "../components/settings/ModelPathSettings.vue";
+import GpuLayersSettings from "../components/settings/GpuLayersSettings.vue";
 import PresetEditor from "../components/settings/PresetEditor.vue";
 import AppTabs from "../components/shared/AppTabs.vue";
 import StopSequencesInput from "../components/settings/StopSequencesInput.vue";


### PR DESCRIPTION
## Summary

- Adds `num_gpu` field to `ChatOptions` on both the Rust and TypeScript sides
- New `GpuLayersSettings.vue` component in Settings → Engine tab: numeric input with hardware-detection summary (GPU name + VRAM)
- G-01 GPU display in ModelsPage shows current offloading mode when partial/CPU-only is configured
- Default value is `-1` (all layers / auto, preserving existing behavior)

Closes #26

## Test plan

- [ ] Open Settings → Engine tab and verify "GPU Layers" section is visible
- [ ] Verify GPU name and VRAM are shown after hardware detection
- [ ] Set `num_gpu` to `0` → label shows "CPU only — no GPU offloading"
- [ ] Set `num_gpu` to `20` → label shows "20 layers on GPU"
- [ ] Set `num_gpu` to `-1` → label shows "All layers (auto)"
- [ ] Open Models page → GPU card shows no extra badge when `num_gpu = -1`
- [ ] With `num_gpu = 0` → GPU card shows "Offloading: CPU only"
- [ ] With `num_gpu = 15` → GPU card shows "Offloading: 15 layers"
- [ ] Start a chat; verify `num_gpu` is sent in the Ollama request options (check network log)
- [ ] `pnpm format && pnpm test` passes
- [ ] `cargo test` passes