### PR TITLE
feat(mo09): model update notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- MO-09: Model update notifications — background digest check every 6 h detects newer versions on ollama.com/library; Models nav item shows an update count badge; each outdated model shows an amber "Update" badge and a one-click re-pull button
 - G-05: GPU layer offloading configuration — Settings → Engine tab now has a "GPU Layers" input (`num_gpu`). Set to `-1` for auto (all layers), `0` for CPU-only, or any positive integer for partial offloading. Current GPU/VRAM is shown as a guide. The G-01 hardware display on the Models page reflects the configured offloading mode.
 - HTTP/SOCKS5 proxy support — configure a proxy URL, optional username, and password (stored in the system keyring) in Settings → Connection; a "Test proxy" button verifies end-to-end connectivity
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,6 +99,7 @@ alpaka-desktop/
 │       │   ├── model_create.rs   # create_model + cancel_model_create (streaming)
 │       │   ├── model_path.rs     # validate_model_path + apply_model_path (systemd override)
 │       │   ├── model_settings.rs # Per-model default options + ChatOptions validation
+│       │   ├── model_updates.rs  # get_models_with_updates, check_model_updates (MO-09)
 │       │   ├── model_user_data.rs# Favorites, tags
 │       │   ├── proxy.rs          # get_proxy_config, save_proxy, delete_proxy, test_proxy
 │       │   ├── service.rs        # Start/stop ollama systemd service
@@ -114,6 +115,7 @@ alpaka-desktop/
 │       │   │   ├── context.rs    # apply_sliding_window (0.85 × num_ctx)
 │       │   │   └── orchestrator.rs # Agent loop (tool calls, max 5 iters)
 │       │   ├── library.rs        # LibraryService: scrape ollama.com/library
+│       │   ├── model_updates.rs  # ModelUpdateService: background 6h loop, digest comparison, do_update_check
 │       │   ├── prompt.rs         # PromptService: context assembly, history
 │       │   └── search.rs         # WebSearchService: tool call execution
 │       │
@@ -500,6 +502,7 @@ Ollama API ──(NDJSON stream)──► Rust (reqwest bytes_stream)
 | `chat:tool-result` | Rust → Vue | `{ conversation_id, tool_name, result }` | Tool call result returned to LLM |
 | `model:pull-progress` | Rust → Vue | `{ model, status, completed?, total?, percent? }` | Download progress chunk |
 | `model:pull-done` | Rust → Vue | `{ model }` | Model download complete |
+| `model:updates-checked` | Rust → Vue | `{ outdated: string[] }` | Background update check result; names of locally installed models with newer versions on ollama.com |
 | `model:create-progress` | Rust → Vue | `{ model: string, status: string }` | Model creation progress status line |
 | `model:create-done` | Rust → Vue | `{ model: string }` | Model creation complete |
 | `model:create-error` | Rust → Vue | `{ model: string, error: string, cancelled: boolean }` | Model creation failed or cancelled |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -359,6 +359,10 @@ tauri::generate_handler![
     commands::service::stop_ollama,
     commands::service::ollama_service_status,
 
+    // ── Model Updates ─────────────────────────────────────────────────────
+    commands::model_updates::get_models_with_updates, // returns cached outdated model names
+    commands::model_updates::check_model_updates,     // triggers an immediate background digest check
+
     // ── System ────────────────────────────────────────────────────────────
     commands::system_info::detect_hardware,  // reads /proc/meminfo + DRM sysfs
     commands::system::report_active_view,    // tracks current page for tray
@@ -398,6 +402,15 @@ pub struct AppState {
 
     /// ID of the conversation currently visible (used by tray notifications).
     pub active_conversation_id: Mutex<Option<String>>,
+
+    /// Cached list of model names that have a newer digest on ollama.com/library.
+    pub models_with_updates: RwLock<Vec<String>>,
+
+    /// Guards against concurrent runs of do_update_check (manual + background loop).
+    pub update_check_running: AtomicBool,
+
+    /// Shutdown signal for the model-update background loop task.
+    pub update_check_loop_shutdown: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 }
 ```
 

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -91,7 +91,7 @@ A **first-class, lightweight Linux desktop client** for Ollama that:
 | MO-06 | **Custom model creation** | P1 | ✅ | Create / edit from Modelfile with streaming progress and cancellation (`CreateModelPage.vue`, `commands/model_create.rs`). Reachable via "Create model" button on Models page |
 | MO-07 | **Model tags / favorites** | P1 | ✅ | Star + free-form tags; filter by tag in model list and selector (`model_user_data.rs`) |
 | MO-08 | **Configurable storage path** | P0 | ✅ | `Settings → Engine`; writes a systemd override and restarts Ollama (`ModelPathSettings.vue`, `commands/model_path.rs`) |
-| MO-09 | **Model update notifications** | P1 | 🔲 Backlog | Detect newer versions of pulled models |
+| MO-09 | **Model update notifications** | P1 | ✅ | Background check every 6 h compares local digest vs `ollama.com/library` hash; nav badge + per-card "Update" indicator; one-click re-pull (`services/model_updates.rs`, `stores/models.ts`) |
 | MO-10 | **Cloud model run** | P0 | ✅ | Cloud tags (`:cloud` suffix) recognised; `addCloudModel` registers the model (`stores/models.ts`) |
 
 ### 2.4 Ollama Cloud Integration

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod library;
 pub mod model_create;
 pub mod model_path;
 pub mod model_settings;
+pub mod model_updates;
 pub mod model_user_data;
 pub mod models;
 pub mod proxy;

--- a/src-tauri/src/commands/model_updates.rs
+++ b/src-tauri/src/commands/model_updates.rs
@@ -1,0 +1,66 @@
+use crate::error::AppError;
+use crate::state::AppState;
+use tauri::{Runtime, State};
+
+#[tauri::command]
+pub async fn get_models_with_updates(
+    state: State<'_, AppState>,
+) -> Result<Vec<String>, AppError> {
+    let cache = state
+        .models_with_updates
+        .read()
+        .unwrap_or_else(|e| e.into_inner());
+    Ok(cache.clone())
+}
+
+#[tauri::command]
+pub async fn check_model_updates<R: Runtime>(
+    app: tauri::AppHandle<R>,
+) -> Result<(), AppError> {
+    tauri::async_runtime::spawn(async move {
+        crate::services::model_updates::do_update_check(&app).await;
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::migrations;
+    use crate::state::AppState;
+    use rusqlite::Connection;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    fn setup_state() -> AppState {
+        let conn = Connection::open_in_memory().unwrap();
+        migrations::run(&conn).unwrap();
+        let db = Arc::new(Mutex::new(conn));
+        AppState::new(db, PathBuf::from("/tmp/test_model_updates.db")).unwrap()
+    }
+
+    #[test]
+    fn get_models_with_updates_returns_cached_list() {
+        let state = setup_state();
+        {
+            let mut cache = state.models_with_updates.write().unwrap();
+            *cache = vec!["llama3:8b".to_string(), "mistral".to_string()];
+        }
+        let result = state
+            .models_with_updates
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        assert_eq!(result, vec!["llama3:8b", "mistral"]);
+    }
+
+    #[test]
+    fn get_models_with_updates_empty_by_default() {
+        let state = setup_state();
+        let result = state
+            .models_with_updates
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        assert!(result.is_empty());
+    }
+}

--- a/src-tauri/src/commands/model_updates.rs
+++ b/src-tauri/src/commands/model_updates.rs
@@ -3,9 +3,7 @@ use crate::state::AppState;
 use tauri::{Runtime, State};
 
 #[tauri::command]
-pub async fn get_models_with_updates(
-    state: State<'_, AppState>,
-) -> Result<Vec<String>, AppError> {
+pub async fn get_models_with_updates(state: State<'_, AppState>) -> Result<Vec<String>, AppError> {
     let cache = state
         .models_with_updates
         .read()
@@ -14,9 +12,7 @@ pub async fn get_models_with_updates(
 }
 
 #[tauri::command]
-pub async fn check_model_updates<R: Runtime>(
-    app: tauri::AppHandle<R>,
-) -> Result<(), AppError> {
+pub async fn check_model_updates<R: Runtime>(app: tauri::AppHandle<R>) -> Result<(), AppError> {
     tauri::async_runtime::spawn(async move {
         crate::services::model_updates::do_update_check(&app).await;
     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,8 @@ pub fn run() {
             commands::system_info::detect_hardware,
             commands::system::report_active_view,
             commands::system::open_browser,
+            commands::model_updates::get_models_with_updates,
+            commands::model_updates::check_model_updates,
             commands::attachments::read_image_file,
         ])
         .setup(|app| {
@@ -159,6 +161,26 @@ pub fn run() {
                 let health_handle =
                     commands::hosts::start_host_health_loop(app.handle().clone(), shutdown_rx);
                 *app.state::<AppState>().health_loop_handle.lock().unwrap() = Some(health_handle);
+            }
+
+            // ── Model update check loop ────────────────────────────────────────
+            #[cfg(not(feature = "test-mode"))]
+            {
+                let (upd_shutdown_tx, upd_shutdown_rx) = tokio::sync::oneshot::channel();
+                *app.state::<AppState>()
+                    .update_check_loop_shutdown
+                    .lock()
+                    .unwrap() = Some(upd_shutdown_tx);
+                let upd_handle = tauri::async_runtime::spawn(
+                    crate::services::model_updates::run_update_check_loop(
+                        app.handle().clone(),
+                        upd_shutdown_rx,
+                    ),
+                );
+                *app.state::<AppState>()
+                    .update_check_loop_handle
+                    .lock()
+                    .unwrap() = Some(upd_handle);
             }
 
             Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -171,16 +171,12 @@ pub fn run() {
                     .update_check_loop_shutdown
                     .lock()
                     .unwrap() = Some(upd_shutdown_tx);
-                let upd_handle = tauri::async_runtime::spawn(
+                let _ = tauri::async_runtime::spawn(
                     crate::services::model_updates::run_update_check_loop(
                         app.handle().clone(),
                         upd_shutdown_rx,
                     ),
                 );
-                *app.state::<AppState>()
-                    .update_check_loop_handle
-                    .lock()
-                    .unwrap() = Some(upd_handle);
             }
 
             Ok(())

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat;
 pub mod library;
+pub mod model_updates;
 pub mod prompt;
 pub mod search;

--- a/src-tauri/src/services/model_updates.rs
+++ b/src-tauri/src/services/model_updates.rs
@@ -33,7 +33,7 @@ pub(crate) fn digest_has_update(local_digest: &str, lib_hash: &str) -> bool {
         return false;
     }
     let local_hex = local_digest.trim_start_matches("sha256:");
-    if local_hex.is_empty() {
+    if local_hex.is_empty() || lib_hash.len() > local_hex.len() {
         return false;
     }
     !local_hex.starts_with(lib_hash)
@@ -201,5 +201,11 @@ mod tests {
     #[test]
     fn empty_local_digest_means_no_update() {
         assert!(!digest_has_update("", "abc123d"));
+    }
+
+    #[test]
+    fn lib_hash_longer_than_local_hex_means_no_update() {
+        // lib_hash longer than local hex must not falsely report an update
+        assert!(!digest_has_update("sha256:abc", "abc123def456789"));
     }
 }

--- a/src-tauri/src/services/model_updates.rs
+++ b/src-tauri/src/services/model_updates.rs
@@ -1,3 +1,12 @@
+use std::time::Duration;
+
+use tauri::{Emitter, Manager, Runtime};
+
+use crate::commands::models::{core_list_models, Model};
+use crate::ollama::client::OllamaClient;
+use crate::services::library;
+use crate::state::AppState;
+
 // Parses `"slug:tag"` or `"slug"` (→ `"latest"` tag).
 // Returns `None` for cloud models (`:cloud` suffix), private models (`/` in name), empty input, or empty slug.
 pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
@@ -28,6 +37,97 @@ pub(crate) fn digest_has_update(local_digest: &str, lib_hash: &str) -> bool {
         return false;
     }
     !local_hex.starts_with(lib_hash)
+}
+
+async fn check_single_model_update(http: &reqwest::Client, model: &Model) -> bool {
+    let (slug, tag) = match parse_model_name(&model.name) {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let tags = match library::get_tags(http, &slug).await {
+        Ok(t) => t,
+        Err(e) => {
+            log::debug!("[model_updates] Could not fetch tags for '{}': {}", slug, e);
+            return false;
+        }
+    };
+
+    let target = format!("{}:{}", slug, tag);
+    match tags.iter().find(|t| t.name == target) {
+        Some(lib_tag) => digest_has_update(&model.digest, &lib_tag.hash),
+        None => false,
+    }
+}
+
+pub(crate) async fn do_update_check<R: Runtime>(app: &tauri::AppHandle<R>) {
+    let state = app.state::<AppState>();
+    let http = state
+        .http_client
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone();
+    let db = state.db.clone();
+
+    let client = match OllamaClient::from_state(http.clone(), db).await {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!("[model_updates] Ollama client unavailable: {}", e);
+            return;
+        }
+    };
+
+    let models = match core_list_models(&client).await {
+        Ok(m) => m,
+        Err(e) => {
+            log::warn!("[model_updates] Could not list models: {}", e);
+            return;
+        }
+    };
+
+    let mut outdated: Vec<String> = Vec::new();
+    for model in &models {
+        if check_single_model_update(&http, model).await {
+            outdated.push(model.name.clone());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    if let Ok(mut cache) = state.models_with_updates.write() {
+        *cache = outdated.clone();
+    }
+
+    log::info!(
+        "[model_updates] Update check complete: {} model(s) outdated",
+        outdated.len()
+    );
+    let _ = app.emit(
+        "model:updates-checked",
+        serde_json::json!({ "outdated": outdated }),
+    );
+}
+
+pub async fn run_update_check_loop<R: Runtime>(
+    app: tauri::AppHandle<R>,
+    shutdown_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    tokio::pin!(shutdown_rx);
+
+    tokio::select! {
+        _ = &mut shutdown_rx => return,
+        _ = tokio::time::sleep(Duration::from_secs(30)) => {}
+    }
+
+    loop {
+        do_update_check(&app).await;
+
+        tokio::select! {
+            _ = &mut shutdown_rx => break,
+            _ = tokio::time::sleep(Duration::from_secs(6 * 3600)) => {}
+        }
+    }
+
+    log::info!("[model_updates] Update check loop shut down.");
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/model_updates.rs
+++ b/src-tauri/src/services/model_updates.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use tauri::{Emitter, Manager, Runtime};
@@ -7,8 +8,6 @@ use crate::ollama::client::OllamaClient;
 use crate::services::library;
 use crate::state::AppState;
 
-// Parses `"slug:tag"` or `"slug"` (→ `"latest"` tag).
-// Returns `None` for cloud models (`:cloud` suffix), private models (`/` in name), empty input, or empty slug.
 pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
     if name.is_empty() || name.contains('/') {
         return None;
@@ -26,8 +25,6 @@ pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
     Some((slug, tag))
 }
 
-// Returns true when `local_digest` (sha256:hex64) does NOT start with `lib_hash` (short 7-12 hex).
-// A mismatch means a newer version is available.
 pub(crate) fn digest_has_update(local_digest: &str, lib_hash: &str) -> bool {
     if lib_hash.is_empty() {
         return false;
@@ -62,6 +59,24 @@ async fn check_single_model_update(http: &reqwest::Client, model: &Model) -> boo
 
 pub(crate) async fn do_update_check<R: Runtime>(app: &tauri::AppHandle<R>) {
     let state = app.state::<AppState>();
+
+    // Only one scan at a time — the manual IPC trigger must not race the background loop.
+    if state
+        .update_check_running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return;
+    }
+    // Reset the flag on every exit path, including early returns.
+    struct Guard<'a>(&'a std::sync::atomic::AtomicBool);
+    impl Drop for Guard<'_> {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::SeqCst);
+        }
+    }
+    let _guard = Guard(&state.update_check_running);
+
     let http = state
         .http_client
         .read()

--- a/src-tauri/src/services/model_updates.rs
+++ b/src-tauri/src/services/model_updates.rs
@@ -1,0 +1,89 @@
+/// Parses `"slug:tag"` or `"slug"` (→ `"latest"` tag).
+/// Returns `None` for cloud models (`:cloud` suffix), private models (`/` in name), or empty input.
+pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
+    if name.is_empty() || name.contains('/') {
+        return None;
+    }
+    let (slug, tag) = name
+        .split_once(':')
+        .map(|(s, t)| (s.to_string(), t.to_string()))
+        .unwrap_or_else(|| (name.to_string(), "latest".to_string()));
+    if tag == "cloud" {
+        return None;
+    }
+    Some((slug, tag))
+}
+
+/// Returns true when `local_digest` (sha256:hex64) does NOT start with `lib_hash` (short 7-12 hex).
+/// A mismatch means a newer version is available.
+pub(crate) fn digest_has_update(local_digest: &str, lib_hash: &str) -> bool {
+    if lib_hash.is_empty() {
+        return false;
+    }
+    let local_hex = local_digest.trim_start_matches("sha256:");
+    !local_hex.starts_with(lib_hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_normal_model_with_tag() {
+        assert_eq!(
+            parse_model_name("llama3:8b"),
+            Some(("llama3".into(), "8b".into()))
+        );
+    }
+
+    #[test]
+    fn parse_model_no_tag_defaults_to_latest() {
+        assert_eq!(
+            parse_model_name("llama3"),
+            Some(("llama3".into(), "latest".into()))
+        );
+    }
+
+    #[test]
+    fn parse_model_with_dots_in_slug() {
+        assert_eq!(
+            parse_model_name("llama3.1:70b"),
+            Some(("llama3.1".into(), "70b".into()))
+        );
+    }
+
+    #[test]
+    fn parse_cloud_model_returns_none() {
+        assert_eq!(parse_model_name("llama3:cloud"), None);
+    }
+
+    #[test]
+    fn parse_private_model_with_slash_returns_none() {
+        assert_eq!(parse_model_name("user/private-model"), None);
+    }
+
+    #[test]
+    fn parse_empty_returns_none() {
+        assert_eq!(parse_model_name(""), None);
+    }
+
+    #[test]
+    fn same_hash_means_no_update() {
+        assert!(!digest_has_update("sha256:abc123def456789", "abc123d"));
+    }
+
+    #[test]
+    fn different_hash_means_update_available() {
+        assert!(digest_has_update("sha256:abc123def456789", "xyz789a"));
+    }
+
+    #[test]
+    fn empty_lib_hash_means_no_update() {
+        assert!(!digest_has_update("sha256:abc123def456789", ""));
+    }
+
+    #[test]
+    fn digest_without_prefix_still_matches() {
+        assert!(!digest_has_update("abc123def456789", "abc123d"));
+    }
+}

--- a/src-tauri/src/services/model_updates.rs
+++ b/src-tauri/src/services/model_updates.rs
@@ -1,5 +1,5 @@
-/// Parses `"slug:tag"` or `"slug"` (→ `"latest"` tag).
-/// Returns `None` for cloud models (`:cloud` suffix), private models (`/` in name), or empty input.
+// Parses `"slug:tag"` or `"slug"` (→ `"latest"` tag).
+// Returns `None` for cloud models (`:cloud` suffix), private models (`/` in name), empty input, or empty slug.
 pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
     if name.is_empty() || name.contains('/') {
         return None;
@@ -8,19 +8,25 @@ pub(crate) fn parse_model_name(name: &str) -> Option<(String, String)> {
         .split_once(':')
         .map(|(s, t)| (s.to_string(), t.to_string()))
         .unwrap_or_else(|| (name.to_string(), "latest".to_string()));
+    if slug.is_empty() {
+        return None;
+    }
     if tag == "cloud" {
         return None;
     }
     Some((slug, tag))
 }
 
-/// Returns true when `local_digest` (sha256:hex64) does NOT start with `lib_hash` (short 7-12 hex).
-/// A mismatch means a newer version is available.
+// Returns true when `local_digest` (sha256:hex64) does NOT start with `lib_hash` (short 7-12 hex).
+// A mismatch means a newer version is available.
 pub(crate) fn digest_has_update(local_digest: &str, lib_hash: &str) -> bool {
     if lib_hash.is_empty() {
         return false;
     }
     let local_hex = local_digest.trim_start_matches("sha256:");
+    if local_hex.is_empty() {
+        return false;
+    }
     !local_hex.starts_with(lib_hash)
 }
 
@@ -85,5 +91,15 @@ mod tests {
     #[test]
     fn digest_without_prefix_still_matches() {
         assert!(!digest_has_update("abc123def456789", "abc123d"));
+    }
+
+    #[test]
+    fn parse_colon_only_returns_none() {
+        assert_eq!(parse_model_name(":"), None);
+    }
+
+    #[test]
+    fn empty_local_digest_means_no_update() {
+        assert!(!digest_has_update("", "abc123d"));
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -44,6 +44,10 @@ pub struct AppState {
 
     /// Tracks the ID of the conversation currently visible to the user.
     pub active_conversation_id: RwLock<Option<String>>,
+
+    pub models_with_updates: RwLock<Vec<String>>,
+    pub update_check_loop_shutdown: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+    pub update_check_loop_handle: std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
 }
 
 /// Builds a reqwest client configured with an optional HTTP or SOCKS5 proxy.
@@ -131,6 +135,9 @@ impl AppState {
             health_loop_handle: std::sync::Mutex::new(None),
             is_chat_view: RwLock::new(true),
             active_conversation_id: RwLock::new(None),
+            models_with_updates: RwLock::new(Vec::new()),
+            update_check_loop_shutdown: Mutex::new(None),
+            update_check_loop_handle: std::sync::Mutex::new(None),
         })
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -47,7 +47,6 @@ pub struct AppState {
 
     pub models_with_updates: RwLock<Vec<String>>,
     pub update_check_loop_shutdown: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
-    pub update_check_loop_handle: std::sync::Mutex<Option<tauri::async_runtime::JoinHandle<()>>>,
 }
 
 /// Builds a reqwest client configured with an optional HTTP or SOCKS5 proxy.
@@ -137,7 +136,6 @@ impl AppState {
             active_conversation_id: RwLock::new(None),
             models_with_updates: RwLock::new(Vec::new()),
             update_check_loop_shutdown: Mutex::new(None),
-            update_check_loop_handle: std::sync::Mutex::new(None),
         })
     }
 }

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::{Mutex, RwLock};
 
 use tokio::sync::{broadcast, oneshot};
@@ -45,7 +46,15 @@ pub struct AppState {
     /// Tracks the ID of the conversation currently visible to the user.
     pub active_conversation_id: RwLock<Option<String>>,
 
+    /// Cached list of locally-installed model names that have a newer digest on ollama.com.
+    /// Written by `do_update_check`; read by the `get_models_with_updates` IPC command.
     pub models_with_updates: RwLock<Vec<String>>,
+
+    /// Set to `true` while a `do_update_check` run is in progress.
+    /// Prevents the manual `check_model_updates` command from spawning a concurrent scan.
+    pub update_check_running: AtomicBool,
+
+    /// Send on this channel to shut down the model-update background loop on app exit.
     pub update_check_loop_shutdown: Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
 }
 
@@ -135,6 +144,7 @@ impl AppState {
             is_chat_view: RwLock::new(true),
             active_conversation_id: RwLock::new(None),
             models_with_updates: RwLock::new(Vec::new()),
+            update_check_running: AtomicBool::new(false),
             update_check_loop_shutdown: Mutex::new(None),
         })
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,6 +99,12 @@
             >
               <span class="block w-full truncate">{{ item.name }}</span>
             </CustomTooltip>
+            <span
+              v-if="navBadges[item.path] > 0"
+              class="ml-auto flex-shrink-0 min-w-[18px] h-[18px] rounded-full bg-[var(--accent)] text-white text-[10px] font-bold flex items-center justify-center px-1 shadow-[0_0_6px_var(--accent)]"
+            >
+              {{ navBadges[item.path] }}
+            </span>
           </div>
         </nav>
 
@@ -229,6 +235,10 @@ const navItems: NavItem[] = [
   { name: "Settings", path: "/settings", icon: IconSettings },
 ];
 
+const navBadges = computed<Record<string, number>>(() => ({
+  "/models": modelStore.updatesAvailableCount,
+}));
+
 function isActive(path: string): boolean {
   return route.path === path;
 }
@@ -268,6 +278,9 @@ onMounted(async () => {
       }),
       initStreamListeners().catch((err: unknown) => {
         console.error("[App] Stream listeners failed:", err);
+      }),
+      modelStore.fetchInitialUpdateStatus().catch((err: unknown) => {
+        console.error("[App] Model update status fetch failed:", err);
       }),
     ]);
 

--- a/src/components/models/ModelCard.vue
+++ b/src/components/models/ModelCard.vue
@@ -61,6 +61,11 @@
                 class="model-card__pulled-badge text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-green-500/10 text-green-500 border border-green-500/20"
                 >Pulled</span
               >
+              <span
+                v-if="hasUpdate"
+                class="model-card__update-badge text-[10px] font-bold uppercase px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-400 border border-amber-500/30"
+                >Update</span
+              >
             </div>
 
             <div
@@ -299,6 +304,7 @@ const props = defineProps<{
   fileSize?: string;
   quant?: string;
   isInstalled?: boolean;
+  hasUpdate?: boolean;
   onClick?: () => void;
   onAction?: () => void;
   actionLabel?: string;

--- a/src/stores/__tests__/models.update.spec.ts
+++ b/src/stores/__tests__/models.update.spec.ts
@@ -1,0 +1,54 @@
+import { setActivePinia, createPinia } from "pinia";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useModelStore } from "../models";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+
+describe("model update state", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("modelsWithUpdates is empty by default", () => {
+    const store = useModelStore();
+    expect(store.modelsWithUpdates.size).toBe(0);
+    expect(store.updatesAvailableCount).toBe(0);
+  });
+
+  it("hasUpdate returns false for unknown model", () => {
+    const store = useModelStore();
+    expect(store.hasUpdate("llama3:8b")).toBe(false);
+  });
+
+  it("fetchInitialUpdateStatus populates modelsWithUpdates", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(["llama3:8b", "mistral"]);
+    const store = useModelStore();
+    await store.fetchInitialUpdateStatus();
+    expect(store.modelsWithUpdates.has("llama3:8b")).toBe(true);
+    expect(store.modelsWithUpdates.has("mistral")).toBe(true);
+    expect(store.updatesAvailableCount).toBe(2);
+    expect(store.hasUpdate("llama3:8b")).toBe(true);
+  });
+
+  it("fetchInitialUpdateStatus handles invoke failure gracefully", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("network error"));
+    const store = useModelStore();
+    await store.fetchInitialUpdateStatus();
+    expect(store.modelsWithUpdates.size).toBe(0);
+  });
+
+  it("modelsWithUpdates can be updated via Set assignment", () => {
+    const store = useModelStore();
+    store.modelsWithUpdates = new Set(["phi3", "gemma"]);
+    expect(store.hasUpdate("phi3")).toBe(true);
+    expect(store.hasUpdate("llama3")).toBe(false);
+    expect(store.updatesAvailableCount).toBe(2);
+  });
+});

--- a/src/stores/__tests__/models.update.spec.ts
+++ b/src/stores/__tests__/models.update.spec.ts
@@ -51,4 +51,42 @@ describe("model update state", () => {
     expect(store.hasUpdate("llama3")).toBe(false);
     expect(store.updatesAvailableCount).toBe(2);
   });
+
+  it("isCheckingUpdates starts false", () => {
+    const store = useModelStore();
+    expect(store.isCheckingUpdates).toBe(false);
+  });
+
+  it("triggerUpdateCheck sets isCheckingUpdates true while running", async () => {
+    let resolve!: () => void;
+    vi.mocked(invoke).mockImplementationOnce(
+      () => new Promise<void>((r) => (resolve = r)),
+    );
+    const store = useModelStore();
+    const promise = store.triggerUpdateCheck();
+    expect(store.isCheckingUpdates).toBe(true);
+    resolve();
+    await promise;
+  });
+
+  it("triggerUpdateCheck resets isCheckingUpdates on invoke failure", async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error("fail"));
+    const store = useModelStore();
+    await store.triggerUpdateCheck();
+    expect(store.isCheckingUpdates).toBe(false);
+  });
+
+  it("triggerUpdateCheck is a no-op when already checking", async () => {
+    let resolve!: () => void;
+    vi.mocked(invoke).mockImplementationOnce(
+      () => new Promise<void>((r) => (resolve = r)),
+    );
+    const store = useModelStore();
+    vi.mocked(invoke).mockClear();
+    store.triggerUpdateCheck(); // don't await — leave it running
+    expect(store.isCheckingUpdates).toBe(true);
+    await store.triggerUpdateCheck(); // second call should return immediately
+    expect(vi.mocked(invoke)).toHaveBeenCalledTimes(1); // only the first call hit invoke
+    resolve();
+  });
 });

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -140,7 +140,7 @@ describe("useModelStore", () => {
     await store.initListeners();
     await store.initListeners();
 
-    expect(mockListen).toHaveBeenCalledTimes(5); // once for each event, not 10
+    expect(mockListen).toHaveBeenCalledTimes(6); // once for each event, not 12
   });
 
   it("fetchModels sets error from tagged-enum object { Http: 'connection refused' }", async () => {

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -655,7 +655,7 @@ describe("useModelStore", () => {
     it("does not pull when model is already installed", async () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest", model: "llama3:latest", ...baseModel },
+        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
       ];
 
       await store.addCloudModel("llama3:latest");

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -649,7 +649,7 @@ describe("useModelStore", () => {
       modified_at: "",
       size: 0,
       digest: "",
-      details: {},
+      details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
     };
 
     it("does not pull when model is already installed", async () => {

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { setActivePinia, createPinia } from "pinia";
 import { useModelStore, modelMatchesTag } from "./models";
+import type { ModelName } from "../types/models";
 
 const mockInvoke = vi.fn();
 vi.mock("@tauri-apps/api/core", () => ({
@@ -15,20 +16,20 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const MOCK_MODELS = [
   {
-    name: "llama3:latest",
+    name: "llama3:latest" as ModelName,
     model: "llama3:latest",
     modified_at: "",
     size: 1000,
     digest: "abc",
-    details: {},
+    details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
   },
   {
-    name: "mistral:latest",
+    name: "mistral:latest" as ModelName,
     model: "mistral:latest",
     modified_at: "",
     size: 2000,
     digest: "def",
-    details: {},
+    details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
   },
 ];
 
@@ -310,20 +311,20 @@ describe("useModelStore", () => {
         const store = useModelStore();
         store.models = [
           {
-            name: "gemma2:9b",
+            name: "gemma2:9b" as ModelName,
             model: "gemma2:9b",
             modified_at: "",
             size: 0,
             digest: "",
-            details: {},
+            details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
           },
           {
-            name: "llama3:8b",
+            name: "llama3:8b" as ModelName,
             model: "llama3:8b",
             modified_at: "",
             size: 0,
             digest: "",
-            details: {},
+            details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
           },
         ];
         store.modelUserData["llama3:8b"] = {
@@ -394,9 +395,12 @@ describe("useModelStore", () => {
           "llama3:8b": { name: "llama3:8b", isFavorite: false, tags: ["fast"] },
         };
         store.capabilities["llama3:8b"] = {
+          name: "llama3:8b" as ModelName,
           vision: true,
           tools: false,
           thinking: false,
+          thinking_toggleable: false,
+          thinking_levels: [],
           embedding: false,
           cloud: false,
           audio: false,
@@ -410,9 +414,12 @@ describe("useModelStore", () => {
       it("includes all capability tag types when present", () => {
         const store = useModelStore();
         store.capabilities["model:latest"] = {
+          name: "model:latest" as ModelName,
           vision: true,
           tools: true,
           thinking: true,
+          thinking_toggleable: false,
+          thinking_levels: [],
           embedding: true,
           cloud: true,
           audio: true,
@@ -500,13 +507,13 @@ describe("useModelStore", () => {
       modified_at: "",
       size: 0,
       digest: "",
-      details: {},
+      details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
     };
 
     it("returns true for exact name match", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest", model: "llama3:latest", ...baseModel },
+        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
       ];
       expect(store.isInstalled("llama3:latest")).toBe(true);
     });
@@ -514,7 +521,7 @@ describe("useModelStore", () => {
     it("returns true when model name starts with prefix + ':'", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest", model: "llama3:latest", ...baseModel },
+        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
       ];
       expect(store.isInstalled("llama3")).toBe(true);
     });
@@ -522,7 +529,7 @@ describe("useModelStore", () => {
     it("returns false when model is not installed", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest", model: "llama3:latest", ...baseModel },
+        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
       ];
       expect(store.isInstalled("mistral")).toBe(false);
     });
@@ -533,20 +540,20 @@ describe("useModelStore", () => {
       const store = useModelStore();
       store.models = [
         {
-          name: "model-a",
+          name: "model-a" as ModelName,
           model: "model-a",
           modified_at: "",
           size: 0,
           digest: "",
-          details: {},
+          details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
         },
         {
-          name: "model-b",
+          name: "model-b" as ModelName,
           model: "model-b",
           modified_at: "",
           size: 0,
           digest: "",
-          details: {},
+          details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
         },
       ];
       const sorted = store.sortedModels;
@@ -559,13 +566,15 @@ describe("useModelStore", () => {
     it("returns cached capabilities without invoking again", async () => {
       const store = useModelStore();
       store.capabilities["llama3:latest"] = {
+        name: "llama3:latest" as ModelName,
         vision: false,
         tools: false,
         thinking: false,
+        thinking_toggleable: false,
+        thinking_levels: [],
         embedding: false,
         cloud: false,
         audio: false,
-        name: "llama3:latest",
       };
       const result = await store.fetchCapabilities("llama3:latest");
       expect(mockInvoke).not.toHaveBeenCalled();

--- a/src/stores/models.test.ts
+++ b/src/stores/models.test.ts
@@ -21,7 +21,14 @@ const MOCK_MODELS = [
     modified_at: "",
     size: 1000,
     digest: "abc",
-    details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+    details: {
+      parent_model: "",
+      format: "gguf",
+      family: "llama",
+      families: null,
+      parameter_size: "8B",
+      quantization_level: "Q4_0",
+    },
   },
   {
     name: "mistral:latest" as ModelName,
@@ -29,7 +36,14 @@ const MOCK_MODELS = [
     modified_at: "",
     size: 2000,
     digest: "def",
-    details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+    details: {
+      parent_model: "",
+      format: "gguf",
+      family: "llama",
+      families: null,
+      parameter_size: "8B",
+      quantization_level: "Q4_0",
+    },
   },
 ];
 
@@ -316,7 +330,14 @@ describe("useModelStore", () => {
             modified_at: "",
             size: 0,
             digest: "",
-            details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+            details: {
+              parent_model: "",
+              format: "gguf",
+              family: "llama",
+              families: null,
+              parameter_size: "8B",
+              quantization_level: "Q4_0",
+            },
           },
           {
             name: "llama3:8b" as ModelName,
@@ -324,7 +345,14 @@ describe("useModelStore", () => {
             modified_at: "",
             size: 0,
             digest: "",
-            details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+            details: {
+              parent_model: "",
+              format: "gguf",
+              family: "llama",
+              families: null,
+              parameter_size: "8B",
+              quantization_level: "Q4_0",
+            },
           },
         ];
         store.modelUserData["llama3:8b"] = {
@@ -507,13 +535,24 @@ describe("useModelStore", () => {
       modified_at: "",
       size: 0,
       digest: "",
-      details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+      details: {
+        parent_model: "",
+        format: "gguf",
+        family: "llama",
+        families: null,
+        parameter_size: "8B",
+        quantization_level: "Q4_0",
+      },
     };
 
     it("returns true for exact name match", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
+        {
+          name: "llama3:latest" as ModelName,
+          model: "llama3:latest",
+          ...baseModel,
+        },
       ];
       expect(store.isInstalled("llama3:latest")).toBe(true);
     });
@@ -521,7 +560,11 @@ describe("useModelStore", () => {
     it("returns true when model name starts with prefix + ':'", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
+        {
+          name: "llama3:latest" as ModelName,
+          model: "llama3:latest",
+          ...baseModel,
+        },
       ];
       expect(store.isInstalled("llama3")).toBe(true);
     });
@@ -529,7 +572,11 @@ describe("useModelStore", () => {
     it("returns false when model is not installed", () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
+        {
+          name: "llama3:latest" as ModelName,
+          model: "llama3:latest",
+          ...baseModel,
+        },
       ];
       expect(store.isInstalled("mistral")).toBe(false);
     });
@@ -545,7 +592,14 @@ describe("useModelStore", () => {
           modified_at: "",
           size: 0,
           digest: "",
-          details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+          details: {
+            parent_model: "",
+            format: "gguf",
+            family: "llama",
+            families: null,
+            parameter_size: "8B",
+            quantization_level: "Q4_0",
+          },
         },
         {
           name: "model-b" as ModelName,
@@ -553,7 +607,14 @@ describe("useModelStore", () => {
           modified_at: "",
           size: 0,
           digest: "",
-          details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+          details: {
+            parent_model: "",
+            format: "gguf",
+            family: "llama",
+            families: null,
+            parameter_size: "8B",
+            quantization_level: "Q4_0",
+          },
         },
       ];
       const sorted = store.sortedModels;
@@ -649,13 +710,24 @@ describe("useModelStore", () => {
       modified_at: "",
       size: 0,
       digest: "",
-      details: { parent_model: "", format: "gguf", family: "llama", families: null, parameter_size: "8B", quantization_level: "Q4_0" },
+      details: {
+        parent_model: "",
+        format: "gguf",
+        family: "llama",
+        families: null,
+        parameter_size: "8B",
+        quantization_level: "Q4_0",
+      },
     };
 
     it("does not pull when model is already installed", async () => {
       const store = useModelStore();
       store.models = [
-        { name: "llama3:latest" as ModelName, model: "llama3:latest", ...baseModel },
+        {
+          name: "llama3:latest" as ModelName,
+          model: "llama3:latest",
+          ...baseModel,
+        },
       ];
 
       await store.addCloudModel("llama3:latest");

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -42,6 +42,7 @@ import type {
   CreateProgressPayload,
   CreateDonePayload,
   CreateErrorPayload,
+  ModelUpdatesCheckedPayload,
 } from "../types/models";
 
 export type { ModelCapabilities };
@@ -63,6 +64,7 @@ export const useModelStore = defineStore("models", {
     isSearching: false,
     _searchTimer: null as ReturnType<typeof setTimeout> | null,
     _searchVersion: 0,
+    modelsWithUpdates: new Set<string>() as Set<string>,
     // Details view state
     selectedModel: null as LibraryModel | null,
     selectedModelTags: [] as LibraryTag[],
@@ -113,6 +115,9 @@ export const useModelStore = defineStore("models", {
       });
       return [...tagSet].sort((a, b) => a.localeCompare(b));
     },
+    hasUpdate: (state) => (name: string) =>
+      state.modelsWithUpdates.has(name),
+    updatesAvailableCount: (state) => state.modelsWithUpdates.size,
   },
   actions: {
     async fetchModels() {
@@ -322,6 +327,22 @@ export const useModelStore = defineStore("models", {
       this.isSearching = false;
       if (this._searchTimer) clearTimeout(this._searchTimer);
     },
+    async fetchInitialUpdateStatus(): Promise<void> {
+      try {
+        const outdated = await invoke<string[]>("get_models_with_updates");
+        this.modelsWithUpdates = new Set(outdated);
+      } catch (e) {
+        console.error("[models] fetchInitialUpdateStatus failed:", e);
+      }
+    },
+
+    async triggerUpdateCheck(): Promise<void> {
+      try {
+        await invoke("check_model_updates");
+      } catch (e) {
+        console.error("[models] triggerUpdateCheck failed:", e);
+      }
+    },
     async initListeners() {
       if (this.listenersInitialized) return;
       const unlistens: Array<() => void> = [];
@@ -335,6 +356,7 @@ export const useModelStore = defineStore("models", {
             listen<{ model: string }>("model:pull-done", (event) => {
               const payload = event.payload;
               delete this.pulling[payload.model];
+              this.modelsWithUpdates.delete(payload.model);
               this.fetchModels();
               this.fetchCapabilities(payload.model);
             }),
@@ -365,6 +387,12 @@ export const useModelStore = defineStore("models", {
                 }
               }
             }),
+            listen<ModelUpdatesCheckedPayload>(
+              "model:updates-checked",
+              (event) => {
+                this.modelsWithUpdates = new Set(event.payload.outdated);
+              },
+            ),
           ])),
         );
         this._unlisten = unlistens;

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -65,6 +65,7 @@ export const useModelStore = defineStore("models", {
     _searchTimer: null as ReturnType<typeof setTimeout> | null,
     _searchVersion: 0,
     modelsWithUpdates: new Set<string>(),
+    isCheckingUpdates: false,
     // Details view state
     selectedModel: null as LibraryModel | null,
     selectedModelTags: [] as LibraryTag[],
@@ -336,10 +337,13 @@ export const useModelStore = defineStore("models", {
     },
 
     async triggerUpdateCheck(): Promise<void> {
+      if (this.isCheckingUpdates) return;
+      this.isCheckingUpdates = true;
       try {
         await invoke("check_model_updates");
       } catch (e) {
         console.error("[models] triggerUpdateCheck failed:", e);
+        this.isCheckingUpdates = false;
       }
     },
     async initListeners() {
@@ -390,6 +394,7 @@ export const useModelStore = defineStore("models", {
               "model:updates-checked",
               (event) => {
                 this.modelsWithUpdates = new Set(event.payload.outdated);
+                this.isCheckingUpdates = false;
               },
             ),
           ])),

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -64,7 +64,7 @@ export const useModelStore = defineStore("models", {
     isSearching: false,
     _searchTimer: null as ReturnType<typeof setTimeout> | null,
     _searchVersion: 0,
-    modelsWithUpdates: new Set<string>() as Set<string>,
+    modelsWithUpdates: new Set<string>(),
     // Details view state
     selectedModel: null as LibraryModel | null,
     selectedModelTags: [] as LibraryTag[],

--- a/src/stores/models.ts
+++ b/src/stores/models.ts
@@ -115,8 +115,7 @@ export const useModelStore = defineStore("models", {
       });
       return [...tagSet].sort((a, b) => a.localeCompare(b));
     },
-    hasUpdate: (state) => (name: string) =>
-      state.modelsWithUpdates.has(name),
+    hasUpdate: (state) => (name: string) => state.modelsWithUpdates.has(name),
     updatesAvailableCount: (state) => state.modelsWithUpdates.size,
   },
   actions: {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -113,3 +113,7 @@ export interface CreateState {
   error?: string;
   logLines: string[];
 }
+
+export interface ModelUpdatesCheckedPayload {
+  outdated: string[];
+}

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -328,6 +328,9 @@
                         :date="formatDateShort(model.modified_at)"
                         :quant="model.details.quantization_level"
                         :is-installed="true"
+                        :has-update="
+                          modelStore.hasUpdate(model.name as string)
+                        "
                         :is-favorite="
                           modelStore.isFavorite(model.name as string)
                         "
@@ -342,7 +345,21 @@
                         :on-edit-tags="
                           () => openTagEditor(model.name as string)
                         "
-                        action-label="Run"
+                        :on-action="
+                          modelStore.hasUpdate(model.name as string)
+                            ? () => modelStore.pullModel(model.name as string)
+                            : undefined
+                        "
+                        :action-label="
+                          modelStore.hasUpdate(model.name as string)
+                            ? 'Update'
+                            : undefined
+                        "
+                        :action-color="
+                          modelStore.hasUpdate(model.name as string)
+                            ? '#fbbf24'
+                            : undefined
+                        "
                       />
                       <!-- Inline tag editor -->
                       <div

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -281,26 +281,30 @@
                     >
                       {{ modelStore.models.length }} Installed Models
                     </p>
-                    <button
-                      @click="modelStore.triggerUpdateCheck()"
-                      class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
-                      title="Check for model updates"
+                    <CustomTooltip
+                      text="Check for model updates"
+                      wrapper-class="inline-flex"
                     >
-                      <svg
-                        width="11"
-                        height="11"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="2.5"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
+                      <button
+                        @click="modelStore.triggerUpdateCheck()"
+                        class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
                       >
-                        <polyline points="23 4 23 10 17 10" />
-                        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-                      </svg>
-                      Check for updates
-                    </button>
+                        <svg
+                          width="11"
+                          height="11"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-width="2.5"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                        >
+                          <polyline points="23 4 23 10 17 10" />
+                          <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                        </svg>
+                        Check for updates
+                      </button>
+                    </CustomTooltip>
                   </div>
                   <!-- Tag filter bar — always visible when models exist -->
                   <div class="flex flex-wrap gap-1.5 mb-3 items-center">

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -328,9 +328,7 @@
                         :date="formatDateShort(model.modified_at)"
                         :quant="model.details.quantization_level"
                         :is-installed="true"
-                        :has-update="
-                          modelStore.hasUpdate(model.name as string)
-                        "
+                        :has-update="modelStore.hasUpdate(model.name as string)"
                         :is-favorite="
                           modelStore.isFavorite(model.name as string)
                         "

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -728,9 +728,10 @@ watch(
   (checking) => {
     if (checking) return;
     if (checkDoneTimer) clearTimeout(checkDoneTimer);
+    const count = modelStore.updatesAvailableCount;
     checkDoneMessage.value =
-      modelStore.updatesAvailableCount > 0
-        ? `${modelStore.updatesAvailableCount} update${modelStore.updatesAvailableCount > 1 ? "s" : ""} available`
+      count > 0
+        ? `${count} ${count > 1 ? "updates" : "update"} available`
         : "All models up to date";
     checkDoneTimer = setTimeout(() => (checkDoneMessage.value = null), 4000);
   },

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -275,11 +275,33 @@
                   </button>
                 </div>
                 <div v-else class="flex flex-col gap-1.5">
-                  <p
-                    class="text-[11px] text-[var(--text-dim)] font-bold uppercase tracking-wider px-1 mb-1"
-                  >
-                    {{ modelStore.models.length }} Installed Models
-                  </p>
+                  <div class="flex items-center justify-between px-1 mb-1">
+                    <p
+                      class="text-[11px] text-[var(--text-dim)] font-bold uppercase tracking-wider"
+                    >
+                      {{ modelStore.models.length }} Installed Models
+                    </p>
+                    <button
+                      @click="modelStore.triggerUpdateCheck()"
+                      class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
+                      title="Check for model updates"
+                    >
+                      <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-width="2.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      >
+                        <polyline points="23 4 23 10 17 10" />
+                        <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                      </svg>
+                      Check for updates
+                    </button>
+                  </div>
                   <!-- Tag filter bar — always visible when models exist -->
                   <div class="flex flex-wrap gap-1.5 mb-3 items-center">
                     <button

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -313,6 +313,19 @@
                         }}
                       </button>
                     </CustomTooltip>
+                    <Transition name="fade-in">
+                      <span
+                        v-if="checkDoneMessage"
+                        class="text-[11px] ml-2"
+                        :class="
+                          modelStore.updatesAvailableCount > 0
+                            ? 'text-amber-400'
+                            : 'text-[var(--text-dim)]'
+                        "
+                      >
+                        {{ checkDoneMessage }}
+                      </span>
+                    </Transition>
                   </div>
                   <!-- Tag filter bar — always visible when models exist -->
                   <div class="flex flex-wrap gap-1.5 mb-3 items-center">
@@ -705,6 +718,21 @@ const settingsStore = useSettingsStore();
 
 const selectedLocalModel = ref<Model | null>(null);
 
+const checkDoneMessage = ref<string | null>(null);
+let checkDoneTimer: ReturnType<typeof setTimeout> | null = null;
+watch(
+  () => modelStore.isCheckingUpdates,
+  (checking) => {
+    if (checking) return;
+    if (checkDoneTimer) clearTimeout(checkDoneTimer);
+    checkDoneMessage.value =
+      modelStore.updatesAvailableCount > 0
+        ? `${modelStore.updatesAvailableCount} update${modelStore.updatesAvailableCount > 1 ? "s" : ""} available`
+        : "All models up to date";
+    checkDoneTimer = setTimeout(() => (checkDoneMessage.value = null), 4000);
+  },
+);
+
 const createModelMode = ref<{
   name: string;
   modelfile: string;
@@ -977,6 +1005,14 @@ onUnmounted(() => {
 .fade-subpage-leave-to {
   opacity: 0;
   transform: scale(1.02) translateY(-10px);
+}
+.fade-in-enter-active,
+.fade-in-leave-active {
+  transition: opacity 0.3s ease;
+}
+.fade-in-enter-from,
+.fade-in-leave-to {
+  opacity: 0;
 }
 
 @keyframes spin {

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -287,7 +287,8 @@
                     >
                       <button
                         @click="modelStore.triggerUpdateCheck()"
-                        class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors"
+                        :disabled="modelStore.isCheckingUpdates"
+                        class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <svg
                           width="11"
@@ -298,11 +299,18 @@
                           stroke-width="2.5"
                           stroke-linecap="round"
                           stroke-linejoin="round"
+                          :class="{
+                            'animate-spin': modelStore.isCheckingUpdates,
+                          }"
                         >
                           <polyline points="23 4 23 10 17 10" />
                           <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
                         </svg>
-                        Check for updates
+                        {{
+                          modelStore.isCheckingUpdates
+                            ? "Checking..."
+                            : "Check for updates"
+                        }}
                       </button>
                     </CustomTooltip>
                   </div>

--- a/src/views/ModelsPage.vue
+++ b/src/views/ModelsPage.vue
@@ -281,42 +281,11 @@
                     >
                       {{ modelStore.models.length }} Installed Models
                     </p>
-                    <CustomTooltip
-                      text="Check for model updates"
-                      wrapper-class="inline-flex"
-                    >
-                      <button
-                        @click="modelStore.triggerUpdateCheck()"
-                        :disabled="modelStore.isCheckingUpdates"
-                        class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        <svg
-                          width="11"
-                          height="11"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          stroke-width="2.5"
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          :class="{
-                            'animate-spin': modelStore.isCheckingUpdates,
-                          }"
-                        >
-                          <polyline points="23 4 23 10 17 10" />
-                          <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
-                        </svg>
-                        {{
-                          modelStore.isCheckingUpdates
-                            ? "Checking..."
-                            : "Check for updates"
-                        }}
-                      </button>
-                    </CustomTooltip>
-                    <Transition name="fade-in">
+                    <Transition name="fade-in" mode="out-in">
                       <span
                         v-if="checkDoneMessage"
-                        class="text-[11px] ml-2"
+                        key="result"
+                        class="text-[11px]"
                         :class="
                           modelStore.updatesAvailableCount > 0
                             ? 'text-amber-400'
@@ -325,6 +294,40 @@
                       >
                         {{ checkDoneMessage }}
                       </span>
+                      <CustomTooltip
+                        v-else
+                        key="btn"
+                        text="Check for model updates"
+                        wrapper-class="inline-flex"
+                      >
+                        <button
+                          @click="modelStore.triggerUpdateCheck()"
+                          :disabled="modelStore.isCheckingUpdates"
+                          class="flex items-center gap-1 text-[11px] text-[var(--text-dim)] hover:text-[var(--text)] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          <svg
+                            width="11"
+                            height="11"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2.5"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            :class="{
+                              'animate-spin': modelStore.isCheckingUpdates,
+                            }"
+                          >
+                            <polyline points="23 4 23 10 17 10" />
+                            <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10" />
+                          </svg>
+                          {{
+                            modelStore.isCheckingUpdates
+                              ? "Checking..."
+                              : "Check for updates"
+                          }}
+                        </button>
+                      </CustomTooltip>
                     </Transition>
                   </div>
                   <!-- Tag filter bar — always visible when models exist -->


### PR DESCRIPTION
## Summary

- Background digest check runs every 6 hours (30 s initial delay) comparing local model digest against the latest tag hash scraped from `ollama.com/library`; outdated model names are cached in `AppState` and broadcast via `model:updates-checked` event
- Models nav item shows a count badge when updates are available; each outdated model card shows an amber "Update" badge and a one-click re-pull action button; a "Check for updates" button on the Installed tab triggers an immediate manual check
- Post-pull: `model:pull-done` removes the model from the outdated set so the badge clears without waiting for the next scheduled check

## Test Plan

- [ ] Pull an older version of a model, then wait for the 30-second startup check (or click "Check for updates") — the Models nav badge and amber "Update" badge appear
- [ ] Click the "Update" action on an outdated model card — progress bar appears, model re-pulls, badges disappear on completion
- [ ] Cloud models (`:cloud` suffix) and private models (`user/name`) do not appear in the outdated set
- [ ] `cargo test --lib` passes (180 tests including 13 for `model_updates` helpers)
- [ ] `pnpm test` passes (693 tests including 5 for the store update actions)

Closes #25