### PR TITLE
feat: C-08/C-08b — conversation export (JSON + Markdown) via sidebar submenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - L-07/L-08: Wire `ErrorScreen.vue` into `App.vue` — connection error overlay now appears when the active Ollama host goes offline, with Retry, Start Ollama Service (localhost only), and Change Host / Settings actions
 
 ### Added
+- C-08/C-08b: Conversation export via sidebar context menu — right-click a conversation → Export → JSON or Markdown; dialog pre-filled with conversation title as default filename; Markdown export strips `<think>` and `<tool_call>` blocks for clean output (#156)
 - Host Manager quick-switch (#155): `Ctrl+H` opens/closes the Host Manager modal from anywhere; modal uses `BaseModal` with CSS variables; other shortcuts are suppressed while it is open
 - Arrow-key navigation in model selector: `↑`/`↓` move through installed models, `Enter` selects, `Escape` closes; `Ctrl+M` is suppressed when the model selector is already open
 - In-place chat compaction (#158): compact button always visible (not gated on 70% context); messages soft-archived with `is_archived` flag; streaming summary saved as `compact_summary` message in the same conversation; streaming status bar shows tokens as they arrive with a Cancel button; sidebar spinner when compacting a background conversation; desktop notification on completion; expandable "Show history" toggle on the summary bubble; "Compaction model" setting in Settings → General

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -320,6 +320,7 @@ tauri::generate_handler![
     commands::chat::send_message,          // delegates to ChatService::send()
     commands::chat::stop_generation,
     commands::chat::export_conversation,
+    commands::chat::export_conversation_markdown,
     commands::chat::backup_database,
     commands::chat::restore_database,
     commands::chat::compact_conversation,  // delegates to ChatService::compact_in_place()

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -58,8 +58,8 @@ A **first-class, lightweight Linux desktop client** for Ollama that:
 | C-05 | **Code blocks with copy button** | P0 | ✅ | Language detection, Shiki syntax highlighting, one-click copy (`CodeBlock.vue`) |
 | C-06 | **Chat history persistence** | P0 | ✅ | SQLite-backed; pin, rename, delete, and search by title (`Ctrl+K` inside `ConversationList.vue`) |
 | C-07 | **Multi-chat tabs/panels** | P1 | 🔲 Backlog | Side-by-side or tabbed conversations |
-| C-08 | **Chat export to JSON** | P1 | 🟡 | `export_conversation` Tauri command implemented and exposed in `lib/tauri.ts`, but no UI button calls it |
-| C-08b | **Chat export to Markdown** | P1 | 🔲 Backlog | Not implemented in backend or UI |
+| C-08 | **Chat export to JSON** | P1 | ✅ | Export submenu in sidebar context menu → JSON option triggers `export_conversation` |
+| C-08b | **Chat export to Markdown** | P1 | ✅ | Export submenu in sidebar context menu → Markdown option triggers `export_conversation_markdown` |
 | C-09 | **Chat branching** | P2 | ✅ | Regenerate assistant responses to create sibling branches; navigate between versions with `<` / `>` controls in `MessageBubble.vue` (`useVersionSwitcher`). Edit message truncates conversation from the edited point before resending. |
 | C-10 | **Chat backup & restore** | P1 | ⚠️ | Raw SQLite backup/restore wired in `Settings → Maintenance`; no per-conversation JSON import/export UI |
 | C-11 | **Compact / TWM mode** | P1 | ⚠️ | `Ctrl+Shift+M` collapses the 48 px icon strip (`App.vue:14`). Padding, font sizes and the top-bar layout described in §3.6 are **not** implemented |

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -239,32 +239,56 @@ pub async fn stop_generation(state: State<'_, AppState>) -> Result<(), AppError>
     Ok(())
 }
 
+/// Shared file-dialog helper for export commands. Returns None if the user cancels.
+async fn run_export_dialog<R: Runtime>(
+    app: &AppHandle<R>,
+    filter_name: &str,
+    extensions: &[&str],
+) -> Result<Option<std::path::PathBuf>, AppError> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.dialog()
+        .file()
+        .add_filter(filter_name, extensions)
+        .save_file(move |file_path| {
+            let _ = tx.send(file_path);
+        });
+    let file_path = rx.await.map_err(|e| AppError::Internal(e.to_string()))?;
+    match file_path {
+        Some(fp) => Ok(Some(
+            fp.into_path().map_err(|e| AppError::Io(e.to_string()))?,
+        )),
+        None => Ok(None),
+    }
+}
+
 #[tauri::command]
 pub async fn export_conversation<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
     conversation_id: String,
 ) -> Result<(), AppError> {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    app.dialog()
-        .file()
-        .add_filter("JSON", &["json"])
-        .save_file(move |file_path| {
-            let _ = tx.send(file_path);
-        });
+    let Some(path) = run_export_dialog(&app, "JSON", &["json"]).await? else {
+        return Ok(());
+    };
+    spawn_db(state.db.clone(), move |conn| {
+        conversations::export_to_path(conn, &conversation_id, &path)
+    })
+    .await
+}
 
-    let default_path = rx.await.map_err(|e| AppError::Internal(e.to_string()))?;
-
-    if let Some(file_path) = default_path {
-        let path = file_path
-            .into_path()
-            .map_err(|e| AppError::Io(e.to_string()))?;
-        spawn_db(state.db.clone(), move |conn| {
-            conversations::export_to_path(conn, &conversation_id, &path)
-        })
-        .await?;
-    }
-    Ok(())
+#[tauri::command]
+pub async fn export_conversation_markdown<R: Runtime>(
+    app: AppHandle<R>,
+    state: State<'_, AppState>,
+    conversation_id: String,
+) -> Result<(), AppError> {
+    let Some(path) = run_export_dialog(&app, "Markdown", &["md"]).await? else {
+        return Ok(());
+    };
+    spawn_db(state.db.clone(), move |conn| {
+        conversations::export_to_markdown_path(conn, &conversation_id, &path)
+    })
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/chat.rs
+++ b/src-tauri/src/commands/chat.rs
@@ -239,19 +239,30 @@ pub async fn stop_generation(state: State<'_, AppState>) -> Result<(), AppError>
     Ok(())
 }
 
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
 /// Shared file-dialog helper for export commands. Returns None if the user cancels.
 async fn run_export_dialog<R: Runtime>(
     app: &AppHandle<R>,
     filter_name: &str,
     extensions: &[&str],
+    default_name: Option<&str>,
 ) -> Result<Option<std::path::PathBuf>, AppError> {
     let (tx, rx) = tokio::sync::oneshot::channel();
-    app.dialog()
-        .file()
-        .add_filter(filter_name, extensions)
-        .save_file(move |file_path| {
-            let _ = tx.send(file_path);
-        });
+    let mut builder = app.dialog().file().add_filter(filter_name, extensions);
+    if let Some(name) = default_name {
+        builder = builder.set_file_name(name);
+    }
+    builder.save_file(move |file_path| {
+        let _ = tx.send(file_path);
+    });
     let file_path = rx.await.map_err(|e| AppError::Internal(e.to_string()))?;
     match file_path {
         Some(fp) => Ok(Some(
@@ -267,7 +278,13 @@ pub async fn export_conversation<R: Runtime>(
     state: State<'_, AppState>,
     conversation_id: String,
 ) -> Result<(), AppError> {
-    let Some(path) = run_export_dialog(&app, "JSON", &["json"]).await? else {
+    let id = conversation_id.clone();
+    let title = spawn_db(state.db.clone(), move |conn| {
+        conversations::get_by_id(conn, &id).map(|c| c.title)
+    })
+    .await?;
+    let default_name = format!("{}.json", sanitize_filename(&title));
+    let Some(path) = run_export_dialog(&app, "JSON", &["json"], Some(&default_name)).await? else {
         return Ok(());
     };
     spawn_db(state.db.clone(), move |conn| {
@@ -282,7 +299,14 @@ pub async fn export_conversation_markdown<R: Runtime>(
     state: State<'_, AppState>,
     conversation_id: String,
 ) -> Result<(), AppError> {
-    let Some(path) = run_export_dialog(&app, "Markdown", &["md"]).await? else {
+    let id = conversation_id.clone();
+    let title = spawn_db(state.db.clone(), move |conn| {
+        conversations::get_by_id(conn, &id).map(|c| c.title)
+    })
+    .await?;
+    let default_name = format!("{}.md", sanitize_filename(&title));
+    let Some(path) = run_export_dialog(&app, "Markdown", &["md"], Some(&default_name)).await?
+    else {
         return Ok(());
     };
     spawn_db(state.db.clone(), move |conn| {

--- a/src-tauri/src/db/conversations.rs
+++ b/src-tauri/src/db/conversations.rs
@@ -275,7 +275,7 @@ pub fn search(conn: &Connection, query: &str) -> Result<Vec<Conversation>, AppEr
 }
 
 /// Fetch the conversation and its active messages — shared by all export formats.
-pub fn fetch_export_data(
+pub(crate) fn fetch_export_data(
     conn: &Connection,
     conversation_id: &str,
 ) -> Result<(Conversation, Vec<crate::db::messages::Message>), AppError> {
@@ -511,6 +511,16 @@ mod tests {
             },
         )
         .unwrap();
+        crate::db::messages::create(
+            &conn,
+            crate::db::messages::NewMessage {
+                conversation_id: conv.id.clone(),
+                role: crate::db::messages::MessageRole::CompactSummary,
+                content: "should_be_skipped".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
 
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("out.md");
@@ -522,5 +532,6 @@ mod tests {
         assert!(content.contains("Hi there"));
         assert!(content.contains("**Assistant:**"));
         assert!(content.contains("Hello!"));
+        assert!(!content.contains("should_be_skipped"));
     }
 }

--- a/src-tauri/src/db/conversations.rs
+++ b/src-tauri/src/db/conversations.rs
@@ -317,7 +317,8 @@ pub fn export_to_markdown_path(
             crate::db::messages::MessageRole::System => "System",
             crate::db::messages::MessageRole::CompactSummary => continue,
         };
-        out.push_str(&format!("**{}:**\n\n{}\n\n---\n\n", label, msg.content));
+        let clean = crate::services::chat::strip_history_content(&msg.content);
+        out.push_str(&format!("**{}:**\n\n{}\n\n---\n\n", label, clean));
     }
     std::fs::write(path, out)?;
     Ok(())
@@ -533,5 +534,42 @@ mod tests {
         assert!(content.contains("**Assistant:**"));
         assert!(content.contains("Hello!"));
         assert!(!content.contains("should_be_skipped"));
+    }
+
+    #[test]
+    fn export_to_markdown_strips_think_and_tool_call_tags() {
+        let conn = in_memory_conn();
+        let conv = create(
+            &conn,
+            NewConversation {
+                title: "Strip Test".into(),
+                model: "llama3".into(),
+                settings_json: None,
+                tags: None,
+            },
+        )
+        .unwrap();
+        crate::db::messages::create(
+            &conn,
+            crate::db::messages::NewMessage {
+                conversation_id: conv.id.clone(),
+                role: crate::db::messages::MessageRole::Assistant,
+                content: "<think>internal reasoning</think>Answer<tool_call>{}</tool_call>".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("strip.md");
+        export_to_markdown_path(&conn, &conv.id, &path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("Answer"));
+        assert!(!content.contains("<think>"));
+        assert!(!content.contains("</think>"));
+        assert!(!content.contains("<tool_call>"));
+        assert!(!content.contains("</tool_call>"));
+        assert!(!content.contains("internal reasoning"));
     }
 }

--- a/src-tauri/src/db/conversations.rs
+++ b/src-tauri/src/db/conversations.rs
@@ -274,22 +274,52 @@ pub fn search(conn: &Connection, query: &str) -> Result<Vec<Conversation>, AppEr
         .collect::<Result<Vec<_>, _>>()
 }
 
-/// Export a conversation and all its messages to a JSON file.
+/// Fetch the conversation and its active messages — shared by all export formats.
+pub fn fetch_export_data(
+    conn: &Connection,
+    conversation_id: &str,
+) -> Result<(Conversation, Vec<crate::db::messages::Message>), AppError> {
+    let conv = get_by_id(conn, conversation_id)?;
+    let msgs = crate::db::messages::list_for_conversation(conn, conversation_id)?;
+    Ok((conv, msgs))
+}
+
+/// Export a conversation to a JSON file.
 pub fn export_to_path(
     conn: &Connection,
     conversation_id: &str,
     path: &std::path::Path,
 ) -> Result<(), AppError> {
-    let conv = get_by_id(conn, conversation_id)?;
-    let msgs = crate::db::messages::list_for_conversation(conn, conversation_id)?;
-
-    let export_data = serde_json::json!({
+    let (conv, msgs) = fetch_export_data(conn, conversation_id)?;
+    let json_str = serde_json::to_string_pretty(&serde_json::json!({
         "conversation": conv,
         "messages": msgs,
-    });
-
-    let json_str = serde_json::to_string_pretty(&export_data)?;
+    }))?;
     std::fs::write(path, json_str)?;
+    Ok(())
+}
+
+/// Export a conversation to a Markdown file.
+pub fn export_to_markdown_path(
+    conn: &Connection,
+    conversation_id: &str,
+    path: &std::path::Path,
+) -> Result<(), AppError> {
+    let (conv, msgs) = fetch_export_data(conn, conversation_id)?;
+    let mut out = format!(
+        "# {}\n\nModel: {}\nDate: {}\n\n---\n\n",
+        conv.title, conv.model, conv.created_at
+    );
+    for msg in &msgs {
+        let label = match msg.role {
+            crate::db::messages::MessageRole::User => "User",
+            crate::db::messages::MessageRole::Assistant => "Assistant",
+            crate::db::messages::MessageRole::System => "System",
+            crate::db::messages::MessageRole::CompactSummary => continue,
+        };
+        out.push_str(&format!("**{}:**\n\n{}\n\n---\n\n", label, msg.content));
+    }
+    std::fs::write(path, out)?;
     Ok(())
 }
 
@@ -416,5 +446,81 @@ mod tests {
 
         let empty = search(&conn, "Python").unwrap();
         assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn fetch_export_data_returns_conversation_and_messages() {
+        let conn = in_memory_conn();
+        let conv = create(
+            &conn,
+            NewConversation {
+                title: "Export Test".into(),
+                model: "llama3".into(),
+                settings_json: None,
+                tags: None,
+            },
+        )
+        .unwrap();
+        crate::db::messages::create(
+            &conn,
+            crate::db::messages::NewMessage {
+                conversation_id: conv.id.clone(),
+                role: crate::db::messages::MessageRole::User,
+                content: "Hello".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let (fetched_conv, msgs) = fetch_export_data(&conn, &conv.id).unwrap();
+        assert_eq!(fetched_conv.title, "Export Test");
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "Hello");
+    }
+
+    #[test]
+    fn export_to_markdown_path_creates_file() {
+        let conn = in_memory_conn();
+        let conv = create(
+            &conn,
+            NewConversation {
+                title: "MD Export".into(),
+                model: "gemma3".into(),
+                settings_json: None,
+                tags: None,
+            },
+        )
+        .unwrap();
+        crate::db::messages::create(
+            &conn,
+            crate::db::messages::NewMessage {
+                conversation_id: conv.id.clone(),
+                role: crate::db::messages::MessageRole::User,
+                content: "Hi there".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        crate::db::messages::create(
+            &conn,
+            crate::db::messages::NewMessage {
+                conversation_id: conv.id.clone(),
+                role: crate::db::messages::MessageRole::Assistant,
+                content: "Hello!".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("out.md");
+        export_to_markdown_path(&conn, &conv.id, &path).unwrap();
+
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("# MD Export"));
+        assert!(content.contains("**User:**"));
+        assert!(content.contains("Hi there"));
+        assert!(content.contains("**Assistant:**"));
+        assert!(content.contains("Hello!"));
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::chat::send_message,
             commands::chat::stop_generation,
             commands::chat::export_conversation,
+            commands::chat::export_conversation_markdown,
             commands::chat::backup_database,
             commands::chat::restore_database,
             commands::chat::compact_conversation,

--- a/src-tauri/src/services/chat/mod.rs
+++ b/src-tauri/src/services/chat/mod.rs
@@ -7,6 +7,7 @@ mod context;
 mod orchestrator;
 
 pub(crate) use context::apply_sliding_window;
+pub(crate) use context::strip_history_content;
 
 use crate::db::repo::AssistantMetrics;
 use crate::db::{messages, spawn_db};

--- a/src/components/sidebar/ConversationList.vue
+++ b/src/components/sidebar/ConversationList.vue
@@ -325,6 +325,7 @@
         @mouseenter="cancelCloseSubmenu"
         @mouseleave="scheduleCloseSubmenu"
         @click.stop
+        @mousedown.stop
       >
         <button
           class="w-full text-left px-3 py-1.5 text-[var(--text)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"

--- a/src/components/sidebar/ConversationList.vue
+++ b/src/components/sidebar/ConversationList.vue
@@ -675,14 +675,22 @@ async function doExportJson() {
   if (!menuConv.value) return;
   const id = menuConv.value.id;
   closeMenuNow();
-  await tauriApi.exportConversation(id);
+  try {
+    await tauriApi.exportConversation(id);
+  } catch (err) {
+    console.error("Export failed:", err);
+  }
 }
 
 async function doExportMarkdown() {
   if (!menuConv.value) return;
   const id = menuConv.value.id;
   closeMenuNow();
-  await tauriApi.exportConversationMarkdown(id);
+  try {
+    await tauriApi.exportConversationMarkdown(id);
+  } catch (err) {
+    console.error("Export failed:", err);
+  }
 }
 
 function closeMenu(e: MouseEvent) {
@@ -724,5 +732,6 @@ onBeforeUnmount(() => {
   document.removeEventListener("mousedown", closeMenu);
   appEvents.removeEventListener(APP_EVENT.FOCUS_SEARCH, openSearch);
   if (observer) observer.disconnect();
+  if (submenuCloseTimer) clearTimeout(submenuCloseTimer);
 });
 </script>

--- a/src/components/sidebar/ConversationList.vue
+++ b/src/components/sidebar/ConversationList.vue
@@ -253,6 +253,40 @@
             {{ menuConv?.pinned ? "Unpin" : "Pin" }}
           </span>
         </button>
+        <button
+          ref="exportItemRef"
+          class="w-full text-left px-3 py-1.5 text-[var(--text)] hover:bg-[var(--bg-hover)] hover:text-[var(--text)] transition-colors cursor-pointer"
+          @mouseenter="openSubmenu"
+          @mouseleave="scheduleCloseSubmenu"
+        >
+          <span class="flex items-center gap-2">
+            <svg
+              class="w-3.5 h-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="7 10 12 15 17 10" />
+              <line x1="12" y1="15" x2="12" y2="3" />
+            </svg>
+            Export
+            <svg
+              class="w-3 h-3 ml-auto"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polyline points="9 18 15 12 9 6" />
+            </svg>
+          </span>
+        </button>
         <div class="my-0.5 border-t border-[var(--border-strong)]"></div>
         <button
           class="w-full text-left px-3 py-1.5 text-[var(--danger)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
@@ -274,6 +308,68 @@
               />
             </svg>
             Delete
+          </span>
+        </button>
+      </div>
+    </Teleport>
+
+    <!-- Export format submenu -->
+    <Teleport to="body">
+      <div
+        v-if="submenuOpen && submenuPosition"
+        class="fixed z-[9999] w-40 bg-[var(--bg-surface)] border border-[var(--border-strong)] rounded-lg shadow-[0_8px_32px_rgba(0,0,0,0.5)] py-1 text-[12px]"
+        :style="{
+          top: submenuPosition.y + 'px',
+          left: submenuPosition.x + 'px',
+        }"
+        @mouseenter="cancelCloseSubmenu"
+        @mouseleave="scheduleCloseSubmenu"
+        @click.stop
+      >
+        <button
+          class="w-full text-left px-3 py-1.5 text-[var(--text)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
+          @click="doExportJson"
+        >
+          <span class="flex items-center gap-2">
+            <svg
+              class="w-3.5 h-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+              />
+              <polyline points="14 2 14 8 20 8" />
+            </svg>
+            JSON
+          </span>
+        </button>
+        <button
+          class="w-full text-left px-3 py-1.5 text-[var(--text)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
+          @click="doExportMarkdown"
+        >
+          <span class="flex items-center gap-2">
+            <svg
+              class="w-3.5 h-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+              />
+              <polyline points="14 2 14 8 20 8" />
+              <line x1="9" y1="15" x2="15" y2="15" />
+              <line x1="9" y1="12" x2="15" y2="12" />
+            </svg>
+            Markdown
           </span>
         </button>
       </div>
@@ -302,6 +398,7 @@ import { useChatStore } from "../../stores/chat";
 import { useConversationLifecycle } from "../../composables/useConversationLifecycle";
 import { useConfirmationModal } from "../../composables/useConfirmationModal";
 import { appEvents, APP_EVENT } from "../../lib/appEvents";
+import { tauriApi } from "../../lib/tauri";
 import type { Conversation } from "../../types/chat";
 
 interface ScrollerItem {
@@ -443,6 +540,10 @@ function closeSearch() {
 const menuOpenId = ref<string | null>(null);
 const menuPosition = ref<{ x: number; y: number } | null>(null);
 const menuRef = ref<HTMLElement | null>(null);
+const exportItemRef = ref<HTMLElement | null>(null);
+const submenuOpen = ref(false);
+const submenuPosition = ref<{ x: number; y: number } | null>(null);
+let submenuCloseTimer: ReturnType<typeof setTimeout> | null = null;
 
 let observer: IntersectionObserver | null = null;
 
@@ -511,6 +612,37 @@ function openContextMenu(e: MouseEvent, conv: Conversation) {
 function closeMenuNow() {
   menuOpenId.value = null;
   menuPosition.value = null;
+  submenuOpen.value = false;
+  submenuPosition.value = null;
+  if (submenuCloseTimer) {
+    clearTimeout(submenuCloseTimer);
+    submenuCloseTimer = null;
+  }
+}
+
+function openSubmenu() {
+  if (submenuCloseTimer) {
+    clearTimeout(submenuCloseTimer);
+    submenuCloseTimer = null;
+  }
+  if (!exportItemRef.value) return;
+  const rect = exportItemRef.value.getBoundingClientRect();
+  submenuPosition.value = { x: rect.right + 2, y: rect.top };
+  submenuOpen.value = true;
+}
+
+function scheduleCloseSubmenu() {
+  submenuCloseTimer = setTimeout(() => {
+    submenuOpen.value = false;
+    submenuPosition.value = null;
+  }, 150);
+}
+
+function cancelCloseSubmenu() {
+  if (submenuCloseTimer) {
+    clearTimeout(submenuCloseTimer);
+    submenuCloseTimer = null;
+  }
 }
 
 function doRename() {
@@ -537,6 +669,20 @@ function doDelete() {
     kind: "danger",
     onConfirm: () => deleteConversation(conv.id),
   });
+}
+
+async function doExportJson() {
+  if (!menuConv.value) return;
+  const id = menuConv.value.id;
+  closeMenuNow();
+  await tauriApi.exportConversation(id);
+}
+
+async function doExportMarkdown() {
+  if (!menuConv.value) return;
+  const id = menuConv.value.id;
+  closeMenuNow();
+  await tauriApi.exportConversationMarkdown(id);
 }
 
 function closeMenu(e: MouseEvent) {

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -145,6 +145,14 @@ describe("tauriApi", () => {
     });
   });
 
+  it("exportConversationMarkdown calls invoke correctly", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce(undefined);
+    await tauriApi.exportConversationMarkdown("c1");
+    expect(invoke).toHaveBeenCalledWith("export_conversation_markdown", {
+      conversationId: "c1",
+    });
+  });
+
   it("backupDatabase calls invoke correctly", async () => {
     vi.mocked(invoke).mockResolvedValueOnce(undefined);
     await tauriApi.backupDatabase();

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -106,6 +106,9 @@ export const tauriApi = {
   exportConversation: (conversationId: string) =>
     invoke<void>("export_conversation", { conversationId }),
 
+  exportConversationMarkdown: (conversationId: string) =>
+    invoke<void>("export_conversation_markdown", { conversationId }),
+
   backupDatabase: () => invoke<void>("backup_database"),
 
   // Models


### PR DESCRIPTION
## Summary
- Adds Export submenu item to the sidebar conversation context menu
- Submenu (hover-triggered, 150ms grace window) offers JSON and Markdown format options
- New `export_conversation_markdown` Tauri command backed by `export_to_markdown_path` in `db/conversations.rs`
- Shared `fetch_export_data` base in `db/conversations.rs`; shared `run_export_dialog` helper in `commands/chat.rs`
- Existing `export_conversation` refactored to use shared infrastructure

Closes #156

## Test plan
- [ ] Right-click a conversation in the sidebar → Export item appears between Pin and Delete
- [ ] Hover Export → submenu appears with JSON and Markdown options
- [ ] Moving mouse from Export item diagonally into submenu keeps it open
- [ ] Click JSON → system file dialog opens with .json filter; file is saved and valid JSON
- [ ] Click Markdown → dialog opens with .md filter; file contains conversation title, model, and messages formatted as `**User:**` / `**Assistant:**`
- [ ] Cancelling the dialog (no file selected) → no error, menus close
- [ ] `pnpm test` passes; `cargo test` passes