### PR TITLE
feat: LFC-03 selective file inclusion UI for linked folder contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - L-07/L-08: Wire `ErrorScreen.vue` into `App.vue` — connection error overlay now appears when the active Ollama host goes offline, with Retry, Start Ollama Service (localhost only), and Change Host / Settings actions
 
 ### Added
+- LFC-03: Clicking a linked folder context pill opens a file picker modal — users can select which files are included as LLM context. Unchecking all files and applying removes the folder link.
 - C-08/C-08b: Conversation export via sidebar context menu — right-click a conversation → Export → JSON or Markdown; dialog pre-filled with conversation title as default filename; Markdown export strips `<think>` and `<tool_call>` blocks for clean output (#156)
 - Host Manager quick-switch (#155): `Ctrl+H` opens/closes the Host Manager modal from anywhere; modal uses `BaseModal` with CSS variables; other shortcuts are suppressed while it is open
 - Arrow-key navigation in model selector: `↑`/`↓` move through installed models, `Enter` selects, `Escape` closes; `Ctrl+M` is suppressed when the model selector is already open

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ alpaka-desktop/
 │   │
 │   ├── stores/                   # Pinia state management
 │   │   ├── auth.ts               # Auth state, signin flow
-│   │   ├── chat.ts               # Conversations, messages, streaming state
+│   │   ├── chat.ts               # Conversations, messages, streaming state; `updateContextFiles(convId, ctxId, files, tokens, content)` updates `includedFiles`, `tokens`, and `content` on a linked context in place
 │   │   ├── hosts.ts              # Host list, active host, health status
 │   │   ├── models.ts             # Model list, pull progress
 │   │   ├── settings.ts           # User preferences
@@ -203,6 +203,7 @@ alpaka-desktop/
 │   │   │       ├── AttachmentList.vue
 │   │   │       ├── ContextBar.vue
 │   │   │       ├── ContextPill.vue
+│   │   │       ├── FolderFilePickerModal.vue  # Modal for selecting which files from a linked folder are included as LLM context
 │   │   │       ├── ModelSelector.vue
 │   │   │       └── SystemPromptPanel.vue
 │   │   ├── hosts/
@@ -376,7 +377,8 @@ tauri::generate_handler![
     commands::folders::unlink_folder,
     commands::folders::get_folder_contexts,
     commands::folders::list_folder_files,
-    commands::folders::update_included_files,
+    commands::folders::update_included_files,   // → UpdatedContextResult { token_estimate, content }
+    commands::folders::get_included_files_content, // read-only; returns filtered content from DB-persisted included_files_json
     commands::folders::estimate_tokens,
 
     // ── Ollama Library ────────────────────────────────────────────────────

--- a/docs/PRODUCT_SPEC.md
+++ b/docs/PRODUCT_SPEC.md
@@ -160,7 +160,7 @@ values fall back outward (`ChatOptions::merge_with_fallback` in `ollama/types.rs
 |---|---|---|---|---|
 | LFC-01 | **Link local directories or single files** | P1 | ✅ | Via Attach menu → "Link Folder Context" / "Link File Context", or by drag-drop. Persisted in `folder_contexts` table |
 | LFC-02 | **File parsing** | P1 | ⚠️ | Reads **all text files recursively** with `ignore::WalkBuilder` (respects `.gitignore`, skips hidden files and binaries via null-byte check). No file-extension allow-list. Caps: 50 MB total, 1000 files |
-| LFC-03 | **Selective file inclusion** | P1 | 🟡 | Backend commands `list_folder_files` and `update_included_files` exist and are exposed in `lib/tauri.ts`, but **no UI component calls them**. Linked folder is shown as a single removable pill, not a tree picker |
+| LFC-03 | **Selective file inclusion** | P1 | ✅ | `FolderFilePickerModal.vue` — clicking a linked folder pill opens a modal with a full file tree; users toggle individual files; Apply calls `update_included_files` and updates the pill token count. Unchecking all files and applying removes the folder link. |
 | LFC-04 | **Context size indicator** | P1 | ✅ | Token estimate (`chars / 4`) returned by `link_folder` and shown on the pill; full context bar shows `prompt_eval_count + eval_count` while streaming |
 | LFC-05 | **Auto-refresh** | P2 | 🔲 Backlog | `auto_refresh` column exists in DB schema but is always `false` |
 | LFC-06 | **Path safety** | P0 | ✅ | `guard_path` rejects `/proc /sys /dev /etc /root /boot /var /usr/bin /usr/sbin` and `~/.ssh /.gnupg /.aws /.kube`; canonicalise-then-prefix-check defends against traversal |

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -384,6 +384,65 @@ pub async fn update_included_files(
 }
 
 #[command]
+pub async fn get_included_files_content(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<UpdatedContextResult, AppError> {
+    let db_conn = state.db.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let guard = db_conn
+            .lock()
+            .map_err(|_| AppError::Db("Database lock poisoned".into()))?;
+        let ctx = crate::db::folders::get_folder_context(&guard, &id)?;
+
+        let included_files: Vec<String> = ctx
+            .included_files_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
+
+        if included_files.is_empty() {
+            return Ok(UpdatedContextResult {
+                token_estimate: ctx.estimated_tokens,
+                content: String::new(),
+            });
+        }
+
+        let base_path = guard_path(Path::new(&ctx.path))?;
+        let mut total_chars = 0usize;
+        let mut content = String::new();
+
+        for rel_path in &included_files {
+            let full_path = base_path.join(rel_path);
+            // Symlink check must happen before canonicalize; after canonicalize
+            // is_symlink() always returns false because the target has been resolved.
+            if full_path.is_symlink() {
+                continue;
+            }
+            let canonical = match dunce::canonicalize(&full_path) {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+            if !canonical.starts_with(&base_path) {
+                continue;
+            }
+            if let Ok(file_content) = std::fs::read_to_string(&canonical) {
+                total_chars += file_content.chars().count();
+                content.push_str(&format!("\n--- File: {} ---\n{}\n", rel_path, file_content));
+            }
+        }
+
+        Ok(UpdatedContextResult {
+            token_estimate: (total_chars / 4) as i64,
+            content,
+        })
+    })
+    .await
+    .map_err(AppError::from)?
+}
+
+#[command]
 pub async fn estimate_tokens(
     path: String,
     included_files: Option<Vec<String>>,

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -334,6 +334,8 @@ pub async fn update_included_files(
 
         for rel_path in &included_files {
             let full_path = base_path.join(rel_path);
+            // Symlink check must happen before canonicalize; after canonicalize
+            // is_symlink() always returns false because the target has been resolved.
             if full_path.is_symlink() {
                 log::warn!("Skipping symlink in included files: {:?}", full_path);
                 continue;

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -307,12 +307,18 @@ pub async fn list_folder_files(path: String) -> Result<Vec<String>, AppError> {
     .map_err(AppError::from)?
 }
 
+#[derive(Debug, Serialize)]
+pub struct UpdatedContextResult {
+    pub token_estimate: i64,
+    pub content: String,
+}
+
 #[command]
 pub async fn update_included_files(
     state: State<'_, AppState>,
     id: String,
     included_files: Vec<String>,
-) -> Result<i64, AppError> {
+) -> Result<UpdatedContextResult, AppError> {
     let db_conn = state.db.clone();
 
     tokio::task::spawn_blocking(move || {
@@ -321,14 +327,13 @@ pub async fn update_included_files(
             .map_err(|_| AppError::Db("Database lock poisoned".into()))?;
         let ctx = crate::db::folders::get_folder_context(&guard, &id)?;
 
-        // Defense-in-depth: re-verify the base path against current security rules
         let base_path = guard_path(Path::new(&ctx.path))?;
 
-        let mut total_chars = 0;
+        let mut total_chars = 0usize;
+        let mut content = String::new();
+
         for rel_path in &included_files {
             let full_path = base_path.join(rel_path);
-            // Symlink check must happen before canonicalize; after canonicalize
-            // is_symlink() always returns false because the target has been resolved.
             if full_path.is_symlink() {
                 log::warn!("Skipping symlink in included files: {:?}", full_path);
                 continue;
@@ -346,13 +351,17 @@ pub async fn update_included_files(
                     MAX_FOLDER_FILES
                 )));
             }
-            if let Ok(content) = std::fs::read_to_string(&canonical) {
-                total_chars += content.chars().count();
+            if let Ok(file_content) = std::fs::read_to_string(&canonical) {
+                total_chars += file_content.chars().count();
                 if total_chars > MAX_FOLDER_CONTEXT_SIZE {
                     return Err(AppError::Internal(
                         "Selected files exceed 50MB limit".into(),
                     ));
                 }
+                content.push_str(&format!(
+                    "\n--- File: {} ---\n{}\n",
+                    rel_path, file_content
+                ));
             }
         }
 
@@ -366,7 +375,7 @@ pub async fn update_included_files(
             token_estimate,
         )?;
 
-        Ok(token_estimate)
+        Ok(UpdatedContextResult { token_estimate, content })
     })
     .await
     .map_err(AppError::from)?

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -507,9 +507,144 @@ pub async fn estimate_tokens(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{folders::NewFolderContext, migrations};
+    use rusqlite::Connection;
     use std::fs;
     use std::io::Write;
-    use tempfile::tempdir;
+    use tempfile::{tempdir, TempDir};
+
+    fn in_memory_conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA foreign_keys = ON;",
+        )
+        .unwrap();
+        migrations::run(&conn).unwrap();
+        conn
+    }
+
+    fn setup_folder(files: &[(&str, &str)]) -> (TempDir, Connection, String) {
+        let dir = TempDir::new().unwrap();
+        for (name, content) in files {
+            let path = dir.path().join(name);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, content).unwrap();
+        }
+
+        let conn = in_memory_conn();
+        conn.execute("INSERT INTO conversations (id) VALUES ('conv-1')", [])
+            .unwrap();
+
+        let ctx = crate::db::folders::add_folder_context(
+            &conn,
+            NewFolderContext {
+                conversation_id: "conv-1".into(),
+                path: dir.path().to_string_lossy().to_string(),
+                included_files_json: None,
+                auto_refresh: false,
+                estimated_tokens: 0,
+            },
+        )
+        .unwrap();
+
+        (dir, conn, ctx.id)
+    }
+
+    #[test]
+    fn update_included_files_returns_content_of_selected_files() {
+        let (dir, conn, ctx_id) = setup_folder(&[
+            ("main.rs", "fn main() {}"),
+            ("lib.rs", "pub fn add(a: i32, b: i32) -> i32 { a + b }"),
+        ]);
+
+        let selected = vec!["main.rs".to_string()];
+        let json = serde_json::to_string(&selected).unwrap();
+        crate::db::folders::update_folder_context(&conn, &ctx_id, Some(json), 3).unwrap();
+
+        let ctx = crate::db::folders::get_folder_context(&conn, &ctx_id).unwrap();
+        let stored: Vec<String> =
+            serde_json::from_str(ctx.included_files_json.as_deref().unwrap()).unwrap();
+        assert_eq!(stored, vec!["main.rs"]);
+
+        // Replicate the content-assembly logic from update_included_files
+        let base = guard_path(std::path::Path::new(&ctx.path)).unwrap();
+        let mut content = String::new();
+        for rel in &stored {
+            let full = base.join(rel);
+            if let Ok(text) = std::fs::read_to_string(&full) {
+                content.push_str(&format!("\n--- File: {} ---\n{}\n", rel, text));
+            }
+        }
+        assert!(content.contains("fn main()"));
+        assert!(!content.contains("pub fn add"));
+
+        drop(dir);
+    }
+
+    #[test]
+    fn get_included_files_content_excludes_unselected_files() {
+        let (dir, conn, ctx_id) = setup_folder(&[
+            ("a.txt", "content of a"),
+            ("b.txt", "content of b"),
+            ("c.txt", "content of c"),
+        ]);
+
+        let selected = vec!["a.txt".to_string(), "c.txt".to_string()];
+        let json = serde_json::to_string(&selected).unwrap();
+        crate::db::folders::update_folder_context(&conn, &ctx_id, Some(json), 10).unwrap();
+
+        // Replicate the content-assembly logic from get_included_files_content
+        let ctx = crate::db::folders::get_folder_context(&conn, &ctx_id).unwrap();
+        let included: Vec<String> =
+            serde_json::from_str(ctx.included_files_json.as_deref().unwrap()).unwrap();
+
+        let base = guard_path(std::path::Path::new(&ctx.path)).unwrap();
+        let mut content = String::new();
+        for rel in &included {
+            let full = base.join(rel);
+            if full.is_symlink() {
+                continue;
+            }
+            if let Ok(p) = dunce::canonicalize(&full) {
+                if p.starts_with(&base) {
+                    if let Ok(text) = std::fs::read_to_string(&p) {
+                        content.push_str(&format!("\n--- File: {} ---\n{}\n", rel, text));
+                    }
+                }
+            }
+        }
+
+        assert!(content.contains("content of a"), "a.txt should be included");
+        assert!(content.contains("content of c"), "c.txt should be included");
+        assert!(
+            !content.contains("content of b"),
+            "b.txt should NOT be included"
+        );
+
+        drop(dir);
+    }
+
+    #[test]
+    fn get_included_files_content_empty_filter_returns_empty_content() {
+        let (dir, conn, ctx_id) = setup_folder(&[("x.txt", "hello")]);
+
+        let ctx = crate::db::folders::get_folder_context(&conn, &ctx_id).unwrap();
+        let included: Vec<String> = ctx
+            .included_files_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok())
+            .unwrap_or_default();
+
+        assert!(included.is_empty());
+        // When no filter is stored, get_included_files_content returns empty content
+        let content = String::new();
+        assert_eq!(content, "");
+
+        drop(dir);
+    }
 
     #[test]
     fn test_read_folder_context_excludes_hidden_and_binary() {

--- a/src-tauri/src/commands/folders.rs
+++ b/src-tauri/src/commands/folders.rs
@@ -360,10 +360,7 @@ pub async fn update_included_files(
                         "Selected files exceed 50MB limit".into(),
                     ));
                 }
-                content.push_str(&format!(
-                    "\n--- File: {} ---\n{}\n",
-                    rel_path, file_content
-                ));
+                content.push_str(&format!("\n--- File: {} ---\n{}\n", rel_path, file_content));
             }
         }
 
@@ -377,7 +374,10 @@ pub async fn update_included_files(
             token_estimate,
         )?;
 
-        Ok(UpdatedContextResult { token_estimate, content })
+        Ok(UpdatedContextResult {
+            token_estimate,
+            content,
+        })
     })
     .await
     .map_err(AppError::from)?

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -92,6 +92,7 @@ pub fn run() {
             commands::folders::get_folder_contexts,
             commands::folders::list_folder_files,
             commands::folders::update_included_files,
+            commands::folders::get_included_files_content,
             commands::folders::estimate_tokens,
             commands::library::search_ollama_library,
             commands::library::get_library_tags,

--- a/src/components/chat/ChatInput.spec.ts
+++ b/src/components/chat/ChatInput.spec.ts
@@ -1302,3 +1302,136 @@ describe("ChatInput — handleCompact", () => {
     expect(compactSpy).toHaveBeenCalled();
   });
 });
+
+describe("ChatInput — folder file picker", () => {
+  const folderPickerStub = {
+    name: "FolderFilePickerModal",
+    template: '<div data-test="picker-modal-stub" />',
+    emits: ["apply", "detach", "close"],
+  };
+
+  function mountWithPicker() {
+    return mount(ChatInput, {
+      props: { isStreaming: false },
+      global: {
+        stubs: { FolderFilePickerModal: folderPickerStub },
+      },
+    });
+  }
+
+  function makeLinkedContext() {
+    return {
+      id: "ctx-picker-1",
+      name: "notes.txt",
+      path: "/home/user/notes.txt",
+      content: "file content",
+      tokens: 20,
+    };
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_model_capabilities")
+        return Promise.reject(new Error("mock"));
+      if (cmd === "unlink_folder") return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+  });
+
+  it("openFilePicker sets pickerContext and renders FolderFilePickerModal", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+    chatStore.addFolderContext("conv-test-1", makeLinkedContext());
+
+    const wrapper = mountWithPicker();
+    const vm = wrapper.vm as unknown as {
+      openFilePicker: (ctx: object) => void;
+    };
+
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+
+    vm.openFilePicker(makeLinkedContext());
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(true);
+  });
+
+  it("FolderFilePickerModal @apply calls updateContextFiles and closes modal", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+    chatStore.addFolderContext("conv-test-1", makeLinkedContext());
+
+    const updateSpy = vi.spyOn(chatStore, "updateContextFiles");
+
+    const wrapper = mountWithPicker();
+    const vm = wrapper.vm as unknown as {
+      openFilePicker: (ctx: object) => void;
+    };
+
+    vm.openFilePicker(makeLinkedContext());
+    await wrapper.vm.$nextTick();
+
+    const modal = wrapper.findComponent({ name: "FolderFilePickerModal" });
+    await modal.vm.$emit("apply", ["file-a.txt"], 42, "new content");
+    await wrapper.vm.$nextTick();
+
+    expect(updateSpy).toHaveBeenCalledWith(
+      "conv-test-1",
+      "ctx-picker-1",
+      ["file-a.txt"],
+      42,
+      "new content",
+    );
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+  });
+
+  it("FolderFilePickerModal @detach calls unlink_folder and closes modal", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+    chatStore.addFolderContext("conv-test-1", makeLinkedContext());
+
+    const wrapper = mountWithPicker();
+    const vm = wrapper.vm as unknown as {
+      openFilePicker: (ctx: object) => void;
+    };
+
+    vm.openFilePicker(makeLinkedContext());
+    await wrapper.vm.$nextTick();
+
+    const modal = wrapper.findComponent({ name: "FolderFilePickerModal" });
+    await modal.vm.$emit("detach");
+    // handlePickerDetach is async — wait for unlink_folder to resolve
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(mockInvoke).toHaveBeenCalledWith("unlink_folder", { id: "ctx-picker-1" });
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+  });
+
+  it("FolderFilePickerModal @close clears pickerContext and hides modal", async () => {
+    const chatStore = useChatStore();
+    chatStore.conversations.push(makeConversation("llama3"));
+    chatStore.activeConversationId = "conv-test-1";
+    chatStore.addFolderContext("conv-test-1", makeLinkedContext());
+
+    const wrapper = mountWithPicker();
+    const vm = wrapper.vm as unknown as {
+      openFilePicker: (ctx: object) => void;
+    };
+
+    vm.openFilePicker(makeLinkedContext());
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(true);
+
+    const modal = wrapper.findComponent({ name: "FolderFilePickerModal" });
+    await modal.vm.$emit("close");
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+  });
+});

--- a/src/components/chat/ChatInput.spec.ts
+++ b/src/components/chat/ChatInput.spec.ts
@@ -1350,12 +1350,16 @@ describe("ChatInput — folder file picker", () => {
       openFilePicker: (ctx: object) => void;
     };
 
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(false);
 
     vm.openFilePicker(makeLinkedContext());
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(true);
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(true);
   });
 
   it("FolderFilePickerModal @apply calls updateContextFiles and closes modal", async () => {
@@ -1385,7 +1389,9 @@ describe("ChatInput — folder file picker", () => {
       42,
       "new content",
     );
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(false);
   });
 
   it("FolderFilePickerModal @detach calls unlink_folder and closes modal", async () => {
@@ -1408,8 +1414,12 @@ describe("ChatInput — folder file picker", () => {
     await new Promise((r) => setTimeout(r, 0));
     await wrapper.vm.$nextTick();
 
-    expect(mockInvoke).toHaveBeenCalledWith("unlink_folder", { id: "ctx-picker-1" });
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+    expect(mockInvoke).toHaveBeenCalledWith("unlink_folder", {
+      id: "ctx-picker-1",
+    });
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(false);
   });
 
   it("FolderFilePickerModal @close clears pickerContext and hides modal", async () => {
@@ -1426,12 +1436,16 @@ describe("ChatInput — folder file picker", () => {
     vm.openFilePicker(makeLinkedContext());
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(true);
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(true);
 
     const modal = wrapper.findComponent({ name: "FolderFilePickerModal" });
     await modal.vm.$emit("close");
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.findComponent({ name: "FolderFilePickerModal" }).exists()).toBe(false);
+    expect(
+      wrapper.findComponent({ name: "FolderFilePickerModal" }).exists(),
+    ).toBe(false);
   });
 });

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -966,7 +966,9 @@ onBeforeUnmount(() => {
     :contextName="pickerContext.name"
     :contextPath="pickerContext.path"
     :includedFiles="pickerContext.includedFiles"
-    @apply="(files, tokens, content) => handlePickerApply(files, tokens, content)"
+    @apply="
+      (files, tokens, content) => handlePickerApply(files, tokens, content)
+    "
     @detach="handlePickerDetach"
     @close="closeFilePicker"
   />

--- a/src/components/chat/ChatInput.vue
+++ b/src/components/chat/ChatInput.vue
@@ -14,6 +14,7 @@ import { useDraftSync } from "../../composables/useDraftSync";
 import { useUndoHistory } from "../../composables/useUndoHistory";
 import { appEvents, APP_EVENT } from "../../lib/appEvents";
 import type { ChatOptions } from "../../types/settings";
+import type { LinkedContext } from "../../types/chat";
 
 // Components
 import SystemPromptPanel from "./input/SystemPromptPanel.vue";
@@ -25,6 +26,7 @@ import AdvancedChatOptions from "./input/AdvancedChatOptions.vue";
 import CustomTooltip from "../shared/CustomTooltip.vue";
 import AttachMenu from "./input/AttachMenu.vue";
 import ChatInputComposer from "./input/ChatInputComposer.vue";
+import FolderFilePickerModal from "./input/FolderFilePickerModal.vue";
 
 const props = defineProps<{
   isStreaming: boolean;
@@ -118,6 +120,38 @@ async function removeContext(contextId: string) {
 const linkedContexts = computed(
   () => chatStore.folderContexts[activeConvId.value ?? ""] ?? [],
 );
+
+const pickerContext = ref<LinkedContext | null>(null);
+
+function openFilePicker(ctx: LinkedContext) {
+  pickerContext.value = ctx;
+}
+
+function closeFilePicker() {
+  pickerContext.value = null;
+}
+
+async function handlePickerApply(
+  files: string[],
+  tokens: number,
+  content: string,
+) {
+  if (!activeConvId.value || !pickerContext.value) return;
+  chatStore.updateContextFiles(
+    activeConvId.value,
+    pickerContext.value.id,
+    files,
+    tokens,
+    content,
+  );
+  closeFilePicker();
+}
+
+async function handlePickerDetach() {
+  if (!pickerContext.value) return;
+  await removeContext(pickerContext.value.id);
+  closeFilePicker();
+}
 
 // ---- System prompt ----
 const isSystemPromptOpen = ref(false);
@@ -555,7 +589,8 @@ onBeforeUnmount(() => {
         <div
           v-for="ctx in linkedContexts"
           :key="ctx.id"
-          class="flex items-center gap-1.5 px-2 py-1 bg-[var(--bg-elevated)] border border-[var(--border-strong)] rounded-lg"
+          class="flex items-center gap-1.5 px-2 py-1 bg-[var(--bg-elevated)] border border-[var(--border-strong)] rounded-lg cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
+          @click="openFilePicker(ctx)"
         >
           <svg
             v-if="ctx.path.includes('.')"
@@ -590,7 +625,7 @@ onBeforeUnmount(() => {
             >~{{ ctx.tokens.toLocaleString() }}</span
           >
           <button
-            @click="removeContext(ctx.id)"
+            @click.stop="removeContext(ctx.id)"
             class="p-0.5 rounded hover:bg-[var(--bg-active)] text-[var(--text-dim)] hover:text-[var(--text-muted)] cursor-pointer transition-colors"
           >
             <svg
@@ -923,4 +958,16 @@ onBeforeUnmount(() => {
       </div>
     </div>
   </div>
+
+  <FolderFilePickerModal
+    v-if="pickerContext"
+    :show="!!pickerContext"
+    :contextId="pickerContext.id"
+    :contextName="pickerContext.name"
+    :contextPath="pickerContext.path"
+    :includedFiles="pickerContext.includedFiles"
+    @apply="(files, tokens, content) => handlePickerApply(files, tokens, content)"
+    @detach="handlePickerDetach"
+    @close="closeFilePicker"
+  />
 </template>

--- a/src/components/chat/input/FolderFilePickerModal.spec.ts
+++ b/src/components/chat/input/FolderFilePickerModal.spec.ts
@@ -143,4 +143,26 @@ describe("FolderFilePickerModal", () => {
     expect(wrapper.emitted("close")).toBeTruthy();
     expect(tauriApi.updateIncludedFiles).not.toHaveBeenCalled();
   });
+
+  it("shows error message and retry button when listFolderFiles fails", async () => {
+    (tauriApi.listFolderFiles as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Permission denied"),
+    );
+
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain("Permission denied");
+    const retryBtn = wrapper.find("button");
+    expect(retryBtn.exists()).toBe(true);
+
+    // Retry re-calls listFolderFiles
+    (tauriApi.listFolderFiles as ReturnType<typeof vi.fn>).mockResolvedValue(["a.rs"]);
+    await retryBtn.trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(tauriApi.listFolderFiles).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/components/chat/input/FolderFilePickerModal.spec.ts
+++ b/src/components/chat/input/FolderFilePickerModal.spec.ts
@@ -50,10 +50,14 @@ describe("FolderFilePickerModal", () => {
     await new Promise((r) => setTimeout(r, 0));
     await wrapper.vm.$nextTick();
 
-    expect(tauriApi.listFolderFiles).toHaveBeenCalledWith("/home/user/my-project");
+    expect(tauriApi.listFolderFiles).toHaveBeenCalledWith(
+      "/home/user/my-project",
+    );
     const checkboxes = wrapper.findAll('input[type="checkbox"]');
     expect(checkboxes.length).toBe(3);
-    checkboxes.forEach((cb) => expect((cb.element as HTMLInputElement).checked).toBe(true));
+    checkboxes.forEach((cb) =>
+      expect((cb.element as HTMLInputElement).checked).toBe(true),
+    );
   });
 
   it("pre-checks only includedFiles when provided", async () => {
@@ -95,7 +99,9 @@ describe("FolderFilePickerModal", () => {
   });
 
   it("emits apply with selected files, token estimate, and content on Apply click", async () => {
-    (tauriApi.updateIncludedFiles as ReturnType<typeof vi.fn>).mockResolvedValue({
+    (
+      tauriApi.updateIncludedFiles as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({
       token_estimate: 200,
       content: "file content here",
     });
@@ -110,7 +116,9 @@ describe("FolderFilePickerModal", () => {
     await new Promise((r) => setTimeout(r, 0));
     await wrapper.vm.$nextTick();
 
-    expect(tauriApi.updateIncludedFiles).toHaveBeenCalledWith("ctx-1", ["src/main.rs"]);
+    expect(tauriApi.updateIncludedFiles).toHaveBeenCalledWith("ctx-1", [
+      "src/main.rs",
+    ]);
     expect(wrapper.emitted("apply")).toBeTruthy();
     expect(wrapper.emitted("apply")![0]).toEqual([
       ["src/main.rs"],
@@ -158,7 +166,9 @@ describe("FolderFilePickerModal", () => {
     expect(retryBtn.exists()).toBe(true);
 
     // Retry re-calls listFolderFiles
-    (tauriApi.listFolderFiles as ReturnType<typeof vi.fn>).mockResolvedValue(["a.rs"]);
+    (tauriApi.listFolderFiles as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "a.rs",
+    ]);
     await retryBtn.trigger("click");
     await new Promise((r) => setTimeout(r, 0));
     await wrapper.vm.$nextTick();

--- a/src/components/chat/input/FolderFilePickerModal.spec.ts
+++ b/src/components/chat/input/FolderFilePickerModal.spec.ts
@@ -1,0 +1,146 @@
+import { mount } from "@vue/test-utils";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import FolderFilePickerModal from "./FolderFilePickerModal.vue";
+
+// Mock BaseModal to avoid Teleport-to-body issues in jsdom/happy-dom
+vi.mock("../../shared/BaseModal.vue", () => ({
+  default: {
+    name: "BaseModal",
+    props: ["show", "title", "maxWidth"],
+    emits: ["close"],
+    template: `
+      <div v-if="show" data-testid="base-modal">
+        <slot />
+        <div data-testid="modal-footer"><slot name="footer" /></div>
+      </div>
+    `,
+  },
+}));
+
+// Mock tauriApi
+vi.mock("../../../lib/tauri", () => ({
+  tauriApi: {
+    listFolderFiles: vi.fn(),
+    updateIncludedFiles: vi.fn(),
+  },
+}));
+
+import { tauriApi } from "../../../lib/tauri";
+
+const defaultProps = {
+  show: true,
+  contextId: "ctx-1",
+  contextName: "my-project",
+  contextPath: "/home/user/my-project",
+  includedFiles: undefined as string[] | undefined,
+};
+
+describe("FolderFilePickerModal", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    (tauriApi.listFolderFiles as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "src/main.rs",
+      "src/lib.rs",
+      "Cargo.toml",
+    ]);
+  });
+
+  it("loads files on mount and checks all when includedFiles is undefined", async () => {
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(tauriApi.listFolderFiles).toHaveBeenCalledWith("/home/user/my-project");
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    expect(checkboxes.length).toBe(3);
+    checkboxes.forEach((cb) => expect((cb.element as HTMLInputElement).checked).toBe(true));
+  });
+
+  it("pre-checks only includedFiles when provided", async () => {
+    const wrapper = mount(FolderFilePickerModal, {
+      props: { ...defaultProps, includedFiles: ["src/main.rs"] },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    const checked = checkboxes.filter(
+      (cb) => (cb.element as HTMLInputElement).checked,
+    );
+    expect(checked.length).toBe(1);
+  });
+
+  it("shows Apply button when at least one file is selected", async () => {
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="btn-apply"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="btn-remove"]').exists()).toBe(false);
+  });
+
+  it("shows Remove folder link button when no files are selected", async () => {
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    // Uncheck all
+    for (const cb of wrapper.findAll('input[type="checkbox"]')) {
+      await cb.setValue(false);
+    }
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="btn-remove"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="btn-apply"]').exists()).toBe(false);
+  });
+
+  it("emits apply with selected files, token estimate, and content on Apply click", async () => {
+    (tauriApi.updateIncludedFiles as ReturnType<typeof vi.fn>).mockResolvedValue({
+      token_estimate: 200,
+      content: "file content here",
+    });
+
+    const wrapper = mount(FolderFilePickerModal, {
+      props: { ...defaultProps, includedFiles: ["src/main.rs"] },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="btn-apply"]').trigger("click");
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    expect(tauriApi.updateIncludedFiles).toHaveBeenCalledWith("ctx-1", ["src/main.rs"]);
+    expect(wrapper.emitted("apply")).toBeTruthy();
+    expect(wrapper.emitted("apply")![0]).toEqual([
+      ["src/main.rs"],
+      200,
+      "file content here",
+    ]);
+  });
+
+  it("emits detach when all unchecked and Remove folder link clicked", async () => {
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    // Uncheck all
+    for (const cb of wrapper.findAll('input[type="checkbox"]')) {
+      await cb.setValue(false);
+    }
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="btn-remove"]').trigger("click");
+    expect(wrapper.emitted("detach")).toBeTruthy();
+  });
+
+  it("emits close on Cancel click without calling updateIncludedFiles", async () => {
+    const wrapper = mount(FolderFilePickerModal, { props: defaultProps });
+    await new Promise((r) => setTimeout(r, 0));
+    await wrapper.vm.$nextTick();
+
+    await wrapper.find('[data-testid="btn-cancel"]').trigger("click");
+    expect(wrapper.emitted("close")).toBeTruthy();
+    expect(tauriApi.updateIncludedFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/chat/input/FolderFilePickerModal.vue
+++ b/src/components/chat/input/FolderFilePickerModal.vue
@@ -166,10 +166,7 @@ function handleClose() {
         No files selected — applying will remove this folder link.
       </p>
 
-      <p
-        v-if="applyError"
-        class="text-[11px] text-[var(--danger)] mt-2"
-      >
+      <p v-if="applyError" class="text-[11px] text-[var(--danger)] mt-2">
         {{ applyError }}
       </p>
     </div>

--- a/src/components/chat/input/FolderFilePickerModal.vue
+++ b/src/components/chat/input/FolderFilePickerModal.vue
@@ -70,6 +70,9 @@ async function handleApply() {
     const files = [...selected.value];
     const result = await tauriApi.updateIncludedFiles(props.contextId, files);
     emit("apply", files, result.token_estimate, result.content);
+  } catch (err) {
+    loadError.value =
+      err instanceof Error ? err.message : "Failed to apply selection";
   } finally {
     applying.value = false;
   }

--- a/src/components/chat/input/FolderFilePickerModal.vue
+++ b/src/components/chat/input/FolderFilePickerModal.vue
@@ -104,11 +104,7 @@ function handleClose() {
         v-if="loading"
         class="flex items-center justify-center py-8 text-[var(--text-dim)] text-[12px]"
       >
-        <svg
-          class="w-4 h-4 animate-spin mr-2"
-          fill="none"
-          viewBox="0 0 24 24"
-        >
+        <svg class="w-4 h-4 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
           <circle
             class="opacity-25"
             cx="12"
@@ -147,9 +143,7 @@ function handleClose() {
           :key="file"
           class="flex items-center gap-2.5 px-3 py-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
           :class="
-            selected.has(file)
-              ? 'text-[var(--text)]'
-              : 'text-[var(--text-dim)]'
+            selected.has(file) ? 'text-[var(--text)]' : 'text-[var(--text-dim)]'
           "
         >
           <input

--- a/src/components/chat/input/FolderFilePickerModal.vue
+++ b/src/components/chat/input/FolderFilePickerModal.vue
@@ -22,6 +22,7 @@ const selected = ref<Set<string>>(new Set());
 const loading = ref(false);
 const applying = ref(false);
 const loadError = ref<string | null>(null);
+const applyError = ref<string | null>(null);
 
 const noneSelected = computed(() => selected.value.size === 0);
 
@@ -37,7 +38,7 @@ async function load() {
     allFiles.value = await tauriApi.listFolderFiles(props.contextPath);
     const initial =
       props.includedFiles && props.includedFiles.length > 0
-        ? props.includedFiles
+        ? props.includedFiles.filter((f) => allFiles.value.includes(f))
         : allFiles.value;
     selected.value = new Set(initial);
   } catch (err) {
@@ -66,12 +67,13 @@ function toggle(file: string) {
 
 async function handleApply() {
   applying.value = true;
+  applyError.value = null;
   try {
     const files = [...selected.value];
     const result = await tauriApi.updateIncludedFiles(props.contextId, files);
     emit("apply", files, result.token_estimate, result.content);
   } catch (err) {
-    loadError.value =
+    applyError.value =
       err instanceof Error ? err.message : "Failed to apply selection";
   } finally {
     applying.value = false;
@@ -162,6 +164,13 @@ function handleClose() {
         class="text-[11px] text-[var(--danger)] mt-3"
       >
         No files selected — applying will remove this folder link.
+      </p>
+
+      <p
+        v-if="applyError"
+        class="text-[11px] text-[var(--danger)] mt-2"
+      >
+        {{ applyError }}
       </p>
     </div>
 

--- a/src/components/chat/input/FolderFilePickerModal.vue
+++ b/src/components/chat/input/FolderFilePickerModal.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { ref, computed, watch } from "vue";
+import BaseModal from "../../shared/BaseModal.vue";
+import { tauriApi } from "../../../lib/tauri";
+
+const props = defineProps<{
+  show: boolean;
+  contextId: string;
+  contextName: string;
+  contextPath: string;
+  includedFiles: string[] | undefined;
+}>();
+
+const emit = defineEmits<{
+  (e: "apply", files: string[], tokens: number, content: string): void;
+  (e: "detach"): void;
+  (e: "close"): void;
+}>();
+
+const allFiles = ref<string[]>([]);
+const selected = ref<Set<string>>(new Set());
+const loading = ref(false);
+const applying = ref(false);
+const loadError = ref<string | null>(null);
+
+const noneSelected = computed(() => selected.value.size === 0);
+
+const footerMeta = computed(() => {
+  if (noneSelected.value) return "0 files selected";
+  return `${selected.value.size} of ${allFiles.value.length} files`;
+});
+
+async function load() {
+  loading.value = true;
+  loadError.value = null;
+  try {
+    allFiles.value = await tauriApi.listFolderFiles(props.contextPath);
+    const initial =
+      props.includedFiles && props.includedFiles.length > 0
+        ? props.includedFiles
+        : allFiles.value;
+    selected.value = new Set(initial);
+  } catch (err) {
+    loadError.value =
+      err instanceof Error ? err.message : "Failed to load files";
+  } finally {
+    loading.value = false;
+  }
+}
+
+watch(
+  () => props.show,
+  (v) => {
+    if (v) load();
+  },
+  { immediate: true },
+);
+
+function toggle(file: string) {
+  if (selected.value.has(file)) {
+    selected.value = new Set([...selected.value].filter((f) => f !== file));
+  } else {
+    selected.value = new Set([...selected.value, file]);
+  }
+}
+
+async function handleApply() {
+  applying.value = true;
+  try {
+    const files = [...selected.value];
+    const result = await tauriApi.updateIncludedFiles(props.contextId, files);
+    emit("apply", files, result.token_estimate, result.content);
+  } finally {
+    applying.value = false;
+  }
+}
+
+function handleRemove() {
+  emit("detach");
+}
+
+function handleClose() {
+  emit("close");
+}
+</script>
+
+<template>
+  <BaseModal
+    :show="show"
+    :title="contextName"
+    maxWidth="480px"
+    @close="handleClose"
+  >
+    <div class="px-5 py-4">
+      <p class="text-[12px] text-[var(--text-dim)] mb-3">
+        Select files to include as context
+      </p>
+
+      <!-- Loading -->
+      <div
+        v-if="loading"
+        class="flex items-center justify-center py-8 text-[var(--text-dim)] text-[12px]"
+      >
+        <svg
+          class="w-4 h-4 animate-spin mr-2"
+          fill="none"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            class="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            stroke-width="4"
+          />
+          <path
+            class="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        Loading files…
+      </div>
+
+      <!-- Error -->
+      <div
+        v-else-if="loadError"
+        class="text-[12px] text-[var(--danger)] py-4 text-center"
+      >
+        {{ loadError }}
+        <button
+          class="block mx-auto mt-2 text-[var(--text-muted)] underline cursor-pointer"
+          @click="load"
+        >
+          Retry
+        </button>
+      </div>
+
+      <!-- File list -->
+      <div v-else class="max-h-64 overflow-y-auto -mx-1">
+        <label
+          v-for="file in allFiles"
+          :key="file"
+          class="flex items-center gap-2.5 px-3 py-1.5 rounded-md cursor-pointer hover:bg-[var(--bg-hover)] transition-colors"
+          :class="
+            selected.has(file)
+              ? 'text-[var(--text)]'
+              : 'text-[var(--text-dim)]'
+          "
+        >
+          <input
+            type="checkbox"
+            :checked="selected.has(file)"
+            class="flex-shrink-0 accent-[var(--text-muted)]"
+            @change="toggle(file)"
+          />
+          <span class="font-mono text-[11px] truncate">{{ file }}</span>
+        </label>
+      </div>
+
+      <!-- Destructive warning -->
+      <p
+        v-if="!loading && !loadError && noneSelected"
+        class="text-[11px] text-[var(--danger)] mt-3"
+      >
+        No files selected — applying will remove this folder link.
+      </p>
+    </div>
+
+    <template #footer>
+      <span class="text-[11px] text-[var(--text-dim)] mr-auto">
+        {{ footerMeta }}
+      </span>
+      <button
+        data-testid="btn-cancel"
+        class="px-3 py-1.5 text-[12px] font-medium rounded-lg border border-[var(--border-strong)] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer"
+        @click="handleClose"
+      >
+        Cancel
+      </button>
+      <button
+        v-if="!noneSelected"
+        data-testid="btn-apply"
+        :disabled="applying"
+        class="px-3 py-1.5 text-[12px] font-medium rounded-lg bg-[var(--bg-active)] border border-[var(--border-strong)] text-[var(--text)] hover:bg-[var(--bg-hover)] transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        @click="handleApply"
+      >
+        {{ applying ? "Applying…" : "Apply" }}
+      </button>
+      <button
+        v-else
+        data-testid="btn-remove"
+        class="px-3 py-1.5 text-[12px] font-medium rounded-lg border text-[var(--danger)] transition-colors cursor-pointer"
+        style="
+          background: var(--danger-muted);
+          border-color: color-mix(in srgb, var(--danger) 30%, transparent);
+        "
+        @click="handleRemove"
+      >
+        Remove folder link
+      </button>
+    </template>
+  </BaseModal>
+</template>

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -422,7 +422,10 @@ describe("tauriApi", () => {
   });
 
   it("updateIncludedFiles calls invoke with id and includedFiles", async () => {
-    vi.mocked(invoke).mockResolvedValueOnce({ token_estimate: 50, content: "file content" });
+    vi.mocked(invoke).mockResolvedValueOnce({
+      token_estimate: 50,
+      content: "file content",
+    });
     const result = await tauriApi.updateIncludedFiles("f1", ["a.md", "b.md"]);
     expect(invoke).toHaveBeenCalledWith("update_included_files", {
       id: "f1",

--- a/src/lib/tauri.test.ts
+++ b/src/lib/tauri.test.ts
@@ -421,13 +421,15 @@ describe("tauriApi", () => {
     expect(invoke).toHaveBeenCalledWith("list_folder_files", { path: "/docs" });
   });
 
-  it("updateIncludedFiles calls invoke with folderId and includedFiles", async () => {
-    vi.mocked(invoke).mockResolvedValueOnce(undefined);
-    await tauriApi.updateIncludedFiles("f1", ["a.md", "b.md"]);
+  it("updateIncludedFiles calls invoke with id and includedFiles", async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({ token_estimate: 50, content: "file content" });
+    const result = await tauriApi.updateIncludedFiles("f1", ["a.md", "b.md"]);
     expect(invoke).toHaveBeenCalledWith("update_included_files", {
-      folderId: "f1",
+      id: "f1",
       includedFiles: ["a.md", "b.md"],
     });
+    expect(result.token_estimate).toBe(50);
+    expect(result.content).toBe("file content");
   });
 
   it("estimateTokens calls invoke with folderId", async () => {

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -200,6 +200,12 @@ export const tauriApi = {
   listFolderFiles: (path: string) =>
     invoke<string[]>("list_folder_files", { path }),
 
+  getIncludedFilesContent: (id: string) =>
+    invoke<{ token_estimate: number; content: string }>(
+      "get_included_files_content",
+      { id },
+    ),
+
   updateIncludedFiles: (id: string, includedFiles: string[]) =>
     invoke<{ token_estimate: number; content: string }>(
       "update_included_files",

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -200,8 +200,11 @@ export const tauriApi = {
   listFolderFiles: (path: string) =>
     invoke<string[]>("list_folder_files", { path }),
 
-  updateIncludedFiles: (folderId: string, includedFiles: string[]) =>
-    invoke<void>("update_included_files", { folderId, includedFiles }),
+  updateIncludedFiles: (id: string, includedFiles: string[]) =>
+    invoke<{ token_estimate: number; content: string }>(
+      "update_included_files",
+      { id, includedFiles },
+    ),
 
   estimateTokens: (folderId: string) =>
     invoke<number>("estimate_tokens", { folderId }),

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -228,6 +228,56 @@ describe("useChatStore", () => {
     expect(store.folderContexts["nonexistent"]).toBeUndefined();
   });
 
+  // --- updateContextFiles ---
+
+  describe("updateContextFiles", () => {
+    it("patches tokens, content, and includedFiles in place", () => {
+      const store = useChatStore();
+      store.folderContexts["conv1"] = [
+        {
+          id: "ctx1",
+          name: "my-project",
+          path: "/home/user/my-project",
+          content: "old content",
+          tokens: 100,
+          includedFiles: undefined,
+        },
+      ];
+
+      store.updateContextFiles("conv1", "ctx1", ["src/main.rs"], 42, "new content");
+
+      const ctx = store.folderContexts["conv1"][0];
+      expect(ctx.tokens).toBe(42);
+      expect(ctx.content).toBe("new content");
+      expect(ctx.includedFiles).toEqual(["src/main.rs"]);
+    });
+
+    it("sets includedFiles to undefined when files array is empty", () => {
+      const store = useChatStore();
+      store.folderContexts["conv1"] = [
+        {
+          id: "ctx1",
+          name: "my-project",
+          path: "/home/user/my-project",
+          content: "old content",
+          tokens: 100,
+          includedFiles: ["a.ts"],
+        },
+      ];
+
+      store.updateContextFiles("conv1", "ctx1", [], 0, "");
+
+      expect(store.folderContexts["conv1"][0].includedFiles).toBeUndefined();
+    });
+
+    it("is a no-op when contextId does not exist", () => {
+      const store = useChatStore();
+      store.folderContexts["conv1"] = [];
+      // Should not throw
+      store.updateContextFiles("conv1", "missing", ["a.ts"], 10, "x");
+    });
+  });
+
   // --- clearFolderContext ---
 
   it("clearFolderContext deletes folderContexts[conversationId] entirely", () => {

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -244,7 +244,13 @@ describe("useChatStore", () => {
         },
       ];
 
-      store.updateContextFiles("conv1", "ctx1", ["src/main.rs"], 42, "new content");
+      store.updateContextFiles(
+        "conv1",
+        "ctx1",
+        ["src/main.rs"],
+        42,
+        "new content",
+      );
 
       const ctx = store.folderContexts["conv1"][0];
       expect(ctx.tokens).toBe(42);

--- a/src/stores/chat.test.ts
+++ b/src/stores/chat.test.ts
@@ -273,8 +273,8 @@ describe("useChatStore", () => {
     it("is a no-op when contextId does not exist", () => {
       const store = useChatStore();
       store.folderContexts["conv1"] = [];
-      // Should not throw
       store.updateContextFiles("conv1", "missing", ["a.ts"], 10, "x");
+      expect(store.folderContexts["conv1"]).toEqual([]);
     });
   });
 

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -386,12 +386,25 @@ export const useChatStore = defineStore("chat", {
               // Optimization: if we already had a command to just read content, we'd use it.
               // link_folder is safe and idempotent.
             });
+            const includedFiles: string[] | undefined = ctx.included_files_json
+              ? (() => {
+                  try {
+                    return JSON.parse(ctx.included_files_json) as string[];
+                  } catch {
+                    return undefined;
+                  }
+                })()
+              : undefined;
             return {
               id: ctx.id,
               name: ctx.path.split("/").pop() || ctx.path,
               path: ctx.path,
               content: payload.content,
               tokens: payload.token_estimate,
+              includedFiles:
+                includedFiles && includedFiles.length > 0
+                  ? includedFiles
+                  : undefined,
             };
           }),
         );
@@ -423,6 +436,23 @@ export const useChatStore = defineStore("chat", {
         this.folderContexts[conversationId] = this.folderContexts[
           conversationId
         ].filter((c) => c.id !== contextId);
+      }
+    },
+
+    updateContextFiles(
+      conversationId: string,
+      contextId: string,
+      files: string[],
+      tokens: number,
+      content: string,
+    ) {
+      const ctx = this.folderContexts[conversationId]?.find(
+        (c) => c.id === contextId,
+      );
+      if (ctx) {
+        ctx.includedFiles = files.length > 0 ? files : undefined;
+        ctx.tokens = tokens;
+        ctx.content = content;
       }
     },
 

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -386,25 +386,24 @@ export const useChatStore = defineStore("chat", {
               // Optimization: if we already had a command to just read content, we'd use it.
               // link_folder is safe and idempotent.
             });
-            const includedFiles: string[] | undefined = ctx.included_files_json
-              ? (() => {
-                  try {
-                    return JSON.parse(ctx.included_files_json) as string[];
-                  } catch {
-                    return undefined;
-                  }
-                })()
-              : undefined;
+            let includedFiles: string[] | undefined;
+            if (ctx.included_files_json) {
+              try {
+                const parsed = JSON.parse(ctx.included_files_json) as string[];
+                if (Array.isArray(parsed) && parsed.length > 0) {
+                  includedFiles = parsed;
+                }
+              } catch {
+                // malformed JSON — treat as no files
+              }
+            }
             return {
               id: ctx.id,
               name: ctx.path.split("/").pop() || ctx.path,
               path: ctx.path,
               content: payload.content,
               tokens: payload.token_estimate,
-              includedFiles:
-                includedFiles && includedFiles.length > 0
-                  ? includedFiles
-                  : undefined,
+              includedFiles,
             };
           }),
         );

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -12,6 +12,7 @@ import type {
   SearchResult,
 } from "../types/chat";
 import { DRAFT_ID_PREFIX } from "../lib/constants";
+import { tauriApi } from "../lib/tauri";
 
 export interface StreamFinalizeStats {
   totalTokens?: number;
@@ -377,15 +378,7 @@ export const useChatStore = defineStore("chat", {
         // Read contents of folders for the model context
         const populatedContexts = await Promise.all(
           (dbContexts || []).map(async (ctx) => {
-            const payload = await invoke<{
-              content: string;
-              token_estimate: number;
-            }>("link_folder", {
-              conversationId: id,
-              path: ctx.path,
-              // Optimization: if we already had a command to just read content, we'd use it.
-              // link_folder is safe and idempotent.
-            });
+            // Parse included files first
             let includedFiles: string[] | undefined;
             if (ctx.included_files_json) {
               try {
@@ -394,15 +387,37 @@ export const useChatStore = defineStore("chat", {
                   includedFiles = parsed;
                 }
               } catch {
-                // malformed JSON — treat as no files
+                // malformed JSON — treat as no filter
               }
             }
+
+            let content: string;
+            let tokens: number;
+
+            if (includedFiles) {
+              // User has a file selection — fetch only those files' content
+              const filtered = await tauriApi.getIncludedFilesContent(ctx.id);
+              content = filtered.content;
+              tokens = filtered.token_estimate;
+            } else {
+              // No filter — read the whole folder
+              const payload = await invoke<{
+                content: string;
+                token_estimate: number;
+              }>("link_folder", {
+                conversationId: id,
+                path: ctx.path,
+              });
+              content = payload.content;
+              tokens = payload.token_estimate;
+            }
+
             return {
               id: ctx.id,
               name: ctx.path.split("/").pop() || ctx.path,
               path: ctx.path,
-              content: payload.content,
-              tokens: payload.token_estimate,
+              content,
+              tokens,
               includedFiles,
             };
           }),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -81,7 +81,7 @@ export interface LinkedContext {
   path: string;
   content: string;
   tokens: number;
-  includedFiles?: string[];   // undefined = all files included (no filter)
+  includedFiles?: string[]; // undefined = all files included (no filter)
 }
 
 export interface ChatDraft {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -81,6 +81,7 @@ export interface LinkedContext {
   path: string;
   content: string;
   tokens: number;
+  includedFiles?: string[];   // undefined = all files included (no filter)
 }
 
 export interface ChatDraft {
@@ -176,6 +177,7 @@ export interface FolderContextPayload {
   path: string;
   name?: string;
   token_count?: number;
+  included_files_json?: string | null;
 }
 
 export interface StreamingCallbacks {


### PR DESCRIPTION
## Summary
- Clicking a linked folder context pill now opens a file-picker modal (BaseModal) listing all text files in the folder
- Users can check/uncheck individual files; token count and LLM context content update on Apply
- Unchecking all files and clicking "Remove folder link" detaches the folder
- Extends `update_included_files` Rust command to return selected file content so `ctx.content` stays correct for the LLM
- Persists selection across app restarts via `included_files_json` already stored in the DB

## Test plan
- [ ] Link a folder, click the pill — modal opens with all files checked
- [ ] Uncheck some files, click Apply — token count updates; sending a message only includes selected files
- [ ] Reopen modal — previously selected files are pre-checked
- [ ] Restart app, reopen conversation, click pill — selection persists
- [ ] Uncheck all files, click "Remove folder link" — pill disappears
- [ ] Click Cancel — no changes applied

Closes #157