### PR TITLE
fix(chat): tool-chain regeneration creates proper dispatch sibling (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Fixed
+- Tool-chain regeneration now creates a proper dispatch sibling, fixing broken version navigation when regenerating a web-search response (#167)
 - L-07/L-08: Wire `ErrorScreen.vue` into `App.vue` — connection error overlay now appears when the active Ollama host goes offline, with Retry, Start Ollama Service (localhost only), and Change Host / Settings actions
 
 ### Added

--- a/src-tauri/src/services/chat/orchestrator.rs
+++ b/src-tauri/src/services/chat/orchestrator.rs
@@ -179,17 +179,15 @@ impl<'a, R: Runtime> ChatService<'a, R> {
                     let db_clone = self.state.db.clone();
 
                     let asst_tool_msg = crate::db::spawn_db(db_clone, move |conn| {
-                        crate::db::messages::create(
+                        crate::db::messages::create_sibling(
                             conn,
+                            &cur_parent,
                             crate::db::messages::NewMessage {
                                 conversation_id: conv_id,
                                 role: crate::db::messages::MessageRole::Assistant,
                                 content: intermediate_content,
-                                parent_id: Some(cur_parent),
                                 tool_calls_json: Some(tool_calls_json_str),
                                 thinking: intermediate_thinking,
-                                sibling_order: 0,
-                                is_active: true,
                                 ..Default::default()
                             },
                         )

--- a/src-tauri/tests/chat_test.rs
+++ b/src-tauri/tests/chat_test.rs
@@ -784,6 +784,160 @@ mod native_roles {
         assert_eq!(path[3].role, messages::MessageRole::Assistant);
         assert!(path[3].tool_calls_json.is_none());
     }
+
+    #[test]
+    fn tool_chain_regenerate_sibling() {
+        let conn = in_memory_conn();
+
+        // ── First generation ──────────────────────────────────────────────────
+        let user = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::User,
+                content: "Search for something".to_string(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // dispatch_1 — created the old way (plain create), simulating how the
+        // first generation is currently persisted by the orchestrator
+        let dispatch_1 = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Assistant,
+                content: "".to_string(),
+                parent_id: Some(user.id.clone()),
+                tool_calls_json: Some(r#"[{"type":"function","function":{"name":"web_search","arguments":{"query":"x"}}}]"#.to_string()),
+                sibling_order: 0,
+                is_active: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let tool_result_1 = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Tool,
+                content: r#"{"results":[]}"#.to_string(),
+                parent_id: Some(dispatch_1.id.clone()),
+                tool_name: Some("web_search".to_string()),
+                sibling_order: 0,
+                is_active: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let _final_1 = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Assistant,
+                content: "First answer".to_string(),
+                parent_id: Some(tool_result_1.id.clone()),
+                sibling_order: 0,
+                is_active: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // ── Regeneration — dispatch_2 via create_sibling (the fix) ────────────
+        let dispatch_2 = messages::create_sibling(
+            &conn,
+            &user.id,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Assistant,
+                content: "".to_string(),
+                tool_calls_json: Some(r#"[{"type":"function","function":{"name":"web_search","arguments":{"query":"x"}}}]"#.to_string()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let tool_result_2 = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Tool,
+                content: r#"{"results":[]}"#.to_string(),
+                parent_id: Some(dispatch_2.id.clone()),
+                tool_name: Some("web_search".to_string()),
+                sibling_order: 0,
+                is_active: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let _final_2 = messages::create(
+            &conn,
+            messages::NewMessage {
+                conversation_id: "c1".to_string(),
+                role: messages::MessageRole::Assistant,
+                content: "Second answer".to_string(),
+                parent_id: Some(tool_result_2.id.clone()),
+                sibling_order: 0,
+                is_active: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        // ── Assertions: sibling structure ─────────────────────────────────────
+        assert_eq!(dispatch_2.sibling_order, 1, "new dispatch must be order 1");
+        assert!(dispatch_2.is_active, "new dispatch must be active");
+
+        // dispatch_1 must be inactive after create_sibling
+        let dispatch_1_refreshed: bool = conn
+            .query_row(
+                "SELECT is_active FROM messages WHERE id = ?1",
+                rusqlite::params![dispatch_1.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(!dispatch_1_refreshed, "old dispatch must be deactivated");
+
+        // sibling_count for dispatch_2 — fetch via list_for_conversation since
+        // create_sibling returns 1 (the value is computed in the list query)
+        let all = messages::list_for_conversation(&conn, "c1").unwrap();
+        let dispatch_2_in_path = all.iter().find(|m| m.id == dispatch_2.id).unwrap();
+        assert_eq!(
+            dispatch_2_in_path.sibling_count, 2,
+            "sibling_count must reflect both dispatches"
+        );
+
+        // ── Assertions: active path shows only second chain ───────────────────
+        let path = messages::list_for_conversation(&conn, "c1").unwrap();
+        let contents: Vec<&str> = path.iter().map(|m| m.content.as_str()).collect();
+        assert!(
+            contents.contains(&"Second answer"),
+            "active path must include second chain final"
+        );
+        assert!(
+            !contents.contains(&"First answer"),
+            "active path must NOT include first chain final"
+        );
+
+        // ── Navigate back to first chain ──────────────────────────────────────
+        messages::set_active_sibling(&conn, &dispatch_1.id).unwrap();
+        let path2 = messages::list_for_conversation(&conn, "c1").unwrap();
+        let contents2: Vec<&str> = path2.iter().map(|m| m.content.as_str()).collect();
+        assert!(
+            contents2.contains(&"First answer"),
+            "after navigate, active path must include first chain final"
+        );
+        assert!(
+            !contents2.contains(&"Second answer"),
+            "after navigate, active path must NOT include second chain final"
+        );
+    }
 }
 
 // ── Chat options / preset forwarding ─────────────────────────────────────────

--- a/src-tauri/tests/chat_test.rs
+++ b/src-tauri/tests/chat_test.rs
@@ -894,7 +894,6 @@ mod native_roles {
         assert_eq!(dispatch_2.sibling_order, 1, "new dispatch must be order 1");
         assert!(dispatch_2.is_active, "new dispatch must be active");
 
-        // dispatch_1 must be inactive after create_sibling
         let dispatch_1_refreshed: bool = conn
             .query_row(
                 "SELECT is_active FROM messages WHERE id = ?1",
@@ -906,15 +905,14 @@ mod native_roles {
 
         // sibling_count for dispatch_2 — fetch via list_for_conversation since
         // create_sibling returns 1 (the value is computed in the list query)
-        let all = messages::list_for_conversation(&conn, "c1").unwrap();
-        let dispatch_2_in_path = all.iter().find(|m| m.id == dispatch_2.id).unwrap();
+        let path = messages::list_for_conversation(&conn, "c1").unwrap();
+        let dispatch_2_in_path = path.iter().find(|m| m.id == dispatch_2.id).unwrap();
         assert_eq!(
             dispatch_2_in_path.sibling_count, 2,
             "sibling_count must reflect both dispatches"
         );
 
         // ── Assertions: active path shows only second chain ───────────────────
-        let path = messages::list_for_conversation(&conn, "c1").unwrap();
         let contents: Vec<&str> = path.iter().map(|m| m.content.as_str()).collect();
         assert!(
             contents.contains(&"Second answer"),


### PR DESCRIPTION
## Summary

- Change dispatch message creation in orchestrator from `messages::create` to `messages::create_sibling` so that regenerating a tool-chain response deactivates the old dispatch and creates the new one as a proper DB sibling
- The version switcher on the user message bubble now correctly shows 1/N, 2/N and allows navigating between full chains after regeneration
- Plain-turn regeneration is unaffected (no existing sibling → `create_sibling` behaves identically to `create`)

## Test plan

- [x] New integration test: `native_roles::tool_chain_regenerate_sibling`
- [x] `cargo test` — all backend tests pass (9 pre-existing zbus runtime conflicts unrelated to this change)
- [x] `pnpm test` — all frontend tests pass

Closes #167